### PR TITLE
feat: glass bento 리디자인 + 사이드바 개편

### DIFF
--- a/apps/studio/src/renderer/index.html
+++ b/apps/studio/src/renderer/index.html
@@ -1,9 +1,18 @@
 <!doctype html>
-<html lang="ko" class="dark">
+<html lang="ko">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Claude Studio</title>
+    <script>
+      // FOUC 방지: 저장된 테마를 즉시 적용
+      try {
+        const theme = localStorage.getItem('theme') ?? 'dark';
+        document.documentElement.classList.add(theme);
+      } catch {
+        document.documentElement.classList.add('dark');
+      }
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/apps/studio/src/renderer/src/pages/live-page.tsx
+++ b/apps/studio/src/renderer/src/pages/live-page.tsx
@@ -68,33 +68,37 @@ export function LivePage() {
   const officeState = officeStateRef.current;
 
   return (
-    <div className="flex flex-col h-full bg-gray-950 text-white">
+    <div className="flex flex-col h-full bg-background text-foreground">
       {/* Header */}
-      <div className="flex items-center justify-between px-4 py-3 border-b border-gray-800">
+      <div className="flex items-center justify-between px-4 py-3 border-b border-border shrink-0">
         <div className="flex items-center gap-2">
-          <span className="text-sm font-medium text-gray-200">라이브 에이전트 (작업중)</span>
+          <span className="text-sm font-medium">라이브 에이전트</span>
+          <span className="text-[10px] font-semibold px-1.5 py-0.5 rounded-sm bg-primary/15 text-primary uppercase tracking-wide">Beta</span>
           {activeAgents.length > 0 && (
-            <span className="flex items-center gap-1 text-xs text-emerald-400">
-              <span className="inline-block w-2 h-2 rounded-full bg-emerald-400 animate-pulse" />
+            <span className="flex items-center gap-1 text-xs text-emerald-500">
+              <span className="relative flex h-1.5 w-1.5">
+                <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-500 opacity-60" />
+                <span className="relative inline-flex rounded-full h-1.5 w-1.5 bg-emerald-500" />
+              </span>
               {activeAgents.length}명 활성
             </span>
           )}
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-1">
           <button
             onClick={() => setZoom((z) => Math.max(1, z - 1))}
-            className="w-6 h-6 flex items-center justify-center rounded bg-gray-800 hover:bg-gray-700 text-gray-300 text-sm leading-none"
+            className="w-6 h-6 flex items-center justify-center rounded border border-border hover:border-primary/30 hover:text-primary text-muted-foreground text-sm leading-none transition-colors"
           >−</button>
-          <span className="text-xs text-gray-500 w-8 text-center">{zoom}x</span>
+          <span className="text-xs text-muted-foreground font-mono w-8 text-center">{zoom}x</span>
           <button
             onClick={() => setZoom((z) => Math.min(10, z + 1))}
-            className="w-6 h-6 flex items-center justify-center rounded bg-gray-800 hover:bg-gray-700 text-gray-300 text-sm leading-none"
+            className="w-6 h-6 flex items-center justify-center rounded border border-border hover:border-primary/30 hover:text-primary text-muted-foreground text-sm leading-none transition-colors"
           >+</button>
         </div>
       </div>
 
       {/* Canvas area */}
-      <div className="flex-1 relative overflow-hidden">
+      <div className="flex-1 relative overflow-hidden min-h-0">
         <OfficeCanvas
           officeState={officeState}
           zoom={zoom}

--- a/apps/studio/src/renderer/src/providers/query-provider.tsx
+++ b/apps/studio/src/renderer/src/providers/query-provider.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { DataProviderWrapper } from '@repo/ui';
+import { DataProviderWrapper, ThemeProvider } from '@repo/ui';
 import { QueryClient, QueryClientProvider, useQueryClient } from '@tanstack/react-query';
 
 import { electronProvider } from './electron-provider';
@@ -68,8 +68,10 @@ export function Providers({ children }: { children: React.ReactNode }) {
   return (
     <QueryClientProvider client={queryClient}>
       <DataProviderWrapper provider={electronProvider}>
-        <DataChangedListener />
-        {children}
+        <ThemeProvider>
+          <DataChangedListener />
+          {children}
+        </ThemeProvider>
       </DataProviderWrapper>
     </QueryClientProvider>
   );

--- a/apps/studio/src/renderer/src/routes/__root.tsx
+++ b/apps/studio/src/renderer/src/routes/__root.tsx
@@ -1,43 +1,71 @@
-import { Sidebar } from '@repo/ui';
-import { createRootRoute, Outlet, useRouter } from '@tanstack/react-router';
+import { AppSidebar, SidebarProvider, SidebarTrigger } from '@repo/ui';
+import { createRootRoute, Outlet, useRouter, useRouterState } from '@tanstack/react-router';
 
 import { ArrowLeft } from 'lucide-react';
+
+const PAGE_TITLES: Record<string, string> = {
+  '/': '개요',
+  '/projects': '프로젝트',
+  '/costs': '비용',
+  '/skills': '스킬',
+  '/data': '설정',
+  '/live': '라이브',
+};
+
+function TopBar() {
+  const routerState = useRouterState();
+  const path = routerState.location.pathname;
+  const title =
+    Object.entries(PAGE_TITLES).find(([key]) =>
+      key === '/' ? path === '/' : path.startsWith(key),
+    )?.[1] ?? '';
+
+  return (
+    <div className="h-10 shrink-0 border-b border-border flex items-center px-3 gap-2.5">
+      <SidebarTrigger className="h-6 w-6 text-muted-foreground hover:text-foreground transition-colors" />
+      <div className="h-3.5 w-px bg-border" />
+      <span className="text-sm font-medium tracking-tight">{title}</span>
+    </div>
+  );
+}
 
 function ErrorComponent({ error }: { error: Error }) {
   const router = useRouter();
   return (
-    <div className="flex min-h-screen bg-background">
-      <Sidebar />
-      <main className="ml-60 flex-1">
-        <div className="mx-auto max-w-7xl px-6 py-6">
+    <SidebarProvider>
+      <AppSidebar />
+      <main className="flex-1 h-svh overflow-hidden flex flex-col">
+        <TopBar />
+        <div className="flex-1 overflow-y-auto px-6 py-5">
           <div className="flex flex-col gap-4">
             <button
               onClick={() => router.history.back()}
-              className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors w-fit"
+              className="flex items-center gap-2 text-xs text-muted-foreground hover:text-foreground transition-colors w-fit"
             >
-              <ArrowLeft className="h-4 w-4" />
+              <ArrowLeft className="h-3.5 w-3.5" />
               뒤로가기
             </button>
-            <div className="rounded-lg border border-destructive/50 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+            <div className="rounded-md border border-destructive/30 bg-destructive/5 px-4 py-3 text-sm text-destructive">
               {error.message}
             </div>
           </div>
         </div>
       </main>
-    </div>
+    </SidebarProvider>
   );
 }
 
 export const Route = createRootRoute({
   component: () => (
-    <div className="flex min-h-screen bg-background">
-      <Sidebar />
-      <main className="ml-60 flex-1 h-screen overflow-y-auto flex flex-col">
-        <div className="mx-auto w-full max-w-7xl px-6 py-6 flex-1 flex flex-col">
+    <SidebarProvider>
+      <AppSidebar />
+      <main className="flex-1 h-svh overflow-hidden flex flex-col">
+        <TopBar />
+        <div className="flex-1 overflow-y-auto px-6 py-5">
           <Outlet />
         </div>
       </main>
-    </div>
+    </SidebarProvider>
   ),
   errorComponent: ErrorComponent,
 });

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -16,6 +16,8 @@
   },
   "dependencies": {
     "@radix-ui/react-accordion": "^1.2.12",
+    "@radix-ui/react-dialog": "^1.1.15",
+    "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-progress": "^1.1.0",
     "@radix-ui/react-scroll-area": "^1.2.0",
     "@radix-ui/react-select": "^2.1.0",
@@ -29,6 +31,7 @@
     "class-variance-authority": "catalog:",
     "clsx": "catalog:",
     "lucide-react": "catalog:",
+    "radix-ui": "^1.4.3",
     "react": "catalog:",
     "react-dom": "catalog:",
     "recharts": "catalog:",

--- a/packages/ui/src/charts/activity-heatmap.tsx
+++ b/packages/ui/src/charts/activity-heatmap.tsx
@@ -10,11 +10,10 @@ interface ActivityHeatmapProps {
 }
 
 function getIntensityStyle(count: number, max: number): CSSProperties {
-  if (count === 0) return { backgroundColor: 'rgba(58, 58, 60, 0.8)' }; // --muted dark
+  if (count === 0) return { backgroundColor: 'color-mix(in srgb, var(--muted-foreground) 15%, transparent)' };
   const ratio = count / max;
-  const opacity =
-    ratio < 0.2 ? 0.25 : ratio < 0.4 ? 0.45 : ratio < 0.6 ? 0.65 : ratio < 0.8 ? 0.82 : 1;
-  return { backgroundColor: `rgba(232, 149, 110, ${opacity})` }; // --primary dark #E8956E
+  const pct = ratio < 0.2 ? 25 : ratio < 0.4 ? 45 : ratio < 0.6 ? 60 : ratio < 0.8 ? 78 : 100;
+  return { backgroundColor: `color-mix(in srgb, var(--primary) ${pct}%, transparent)` };
 }
 
 export function ActivityHeatmap({ data }: ActivityHeatmapProps) {
@@ -63,14 +62,14 @@ export function ActivityHeatmap({ data }: ActivityHeatmapProps) {
       </div>
       <div className="flex items-center justify-end gap-1 text-[10px] text-muted-foreground">
         <span>적음</span>
-        {([0, 0.25, 0.45, 0.65, 0.82, 1] as const).map((opacity) => (
+        {([0, 25, 45, 60, 78, 100] as const).map((pct) => (
           <div
-            key={opacity}
+            key={pct}
             className="h-[10px] w-[10px] rounded-sm"
             style={
-              opacity === 0
-                ? { backgroundColor: 'rgba(58, 58, 60, 0.8)' }
-                : { backgroundColor: `rgba(232, 149, 110, ${opacity})` }
+              pct === 0
+                ? { backgroundColor: 'color-mix(in srgb, var(--muted-foreground) 15%, transparent)' }
+                : { backgroundColor: `color-mix(in srgb, var(--primary) ${pct}%, transparent)` }
             }
           />
         ))}

--- a/packages/ui/src/charts/cache-stats.tsx
+++ b/packages/ui/src/charts/cache-stats.tsx
@@ -39,25 +39,25 @@ export function CacheStatsCard({ data }: CacheStatsCardProps) {
     <TooltipProvider delayDuration={300}>
       <div className="space-y-4">
         <div className="grid grid-cols-2 gap-3">
-          <div className="rounded-lg bg-muted/50 p-3">
+          <div className="rounded-lg border border-border/50 p-3">
             <FieldLabel label="캐시 적중률" tooltip={TOOLTIPS.cacheHitRate} />
-            <p className="text-xl font-semibold mt-1">{data.cacheHitRate}%</p>
+            <p className="text-xl font-semibold font-mono mt-1">{data.cacheHitRate}%</p>
           </div>
-          <div className="rounded-lg bg-muted/50 p-3">
+          <div className="rounded-lg border border-border/50 p-3">
             <FieldLabel label="절약 비용" tooltip={TOOLTIPS.estimatedSavings} />
-            <p className="text-xl font-semibold mt-1 text-primary">
+            <p className="text-xl font-semibold font-mono mt-1 text-primary">
               {formatCost(data.estimatedSavingsUsd)}
             </p>
           </div>
-          <div className="rounded-lg bg-muted/50 p-3">
+          <div className="rounded-lg border border-border/50 p-3">
             <FieldLabel label="캐시 생성 토큰" tooltip={TOOLTIPS.cacheCreation} />
-            <p className="text-lg font-semibold mt-1">
+            <p className="text-lg font-semibold font-mono mt-1">
               {formatTokens(data.totalCacheCreationTokens)}
             </p>
           </div>
-          <div className="rounded-lg bg-muted/50 p-3">
+          <div className="rounded-lg border border-border/50 p-3">
             <FieldLabel label="캐시 읽기 토큰" tooltip={TOOLTIPS.cacheRead} />
-            <p className="text-lg font-semibold mt-1">{formatTokens(data.totalCacheReadTokens)}</p>
+            <p className="text-lg font-semibold font-mono mt-1">{formatTokens(data.totalCacheReadTokens)}</p>
           </div>
         </div>
 

--- a/packages/ui/src/charts/conversation-stats.tsx
+++ b/packages/ui/src/charts/conversation-stats.tsx
@@ -17,23 +17,23 @@ export function ConversationStatsCard({ data }: ConversationStatsCardProps) {
   return (
     <div className="space-y-4">
       <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
-        <div className="rounded-lg bg-muted/50 p-3">
+        <div className="rounded-lg border border-border/50 p-3">
           <p className="text-xs text-muted-foreground">평균 세션 길이</p>
-          <p className="text-lg font-semibold mt-1">{formatDuration(data.avgSessionDurationMs)}</p>
+          <p className="text-lg font-semibold font-mono mt-1">{formatDuration(data.avgSessionDurationMs)}</p>
         </div>
-        <div className="rounded-lg bg-muted/50 p-3">
+        <div className="rounded-lg border border-border/50 p-3">
           <p className="text-xs text-muted-foreground">세션당 평균 메시지</p>
-          <p className="text-lg font-semibold mt-1">{Math.round(data.avgMessagesPerSession)}개</p>
+          <p className="text-lg font-semibold font-mono mt-1">{Math.round(data.avgMessagesPerSession)}개</p>
         </div>
-        <div className="rounded-lg bg-muted/50 p-3">
+        <div className="rounded-lg border border-border/50 p-3">
           <p className="text-xs text-muted-foreground">입력 토큰/메시지</p>
-          <p className="text-lg font-semibold mt-1">
+          <p className="text-lg font-semibold font-mono mt-1">
             {formatTokens(Math.round(data.avgInputTokensPerMessage))}
           </p>
         </div>
-        <div className="rounded-lg bg-muted/50 p-3">
+        <div className="rounded-lg border border-border/50 p-3">
           <p className="text-xs text-muted-foreground">출력 토큰/메시지</p>
-          <p className="text-lg font-semibold mt-1">
+          <p className="text-lg font-semibold font-mono mt-1">
             {formatTokens(Math.round(data.avgOutputTokensPerMessage))}
           </p>
         </div>

--- a/packages/ui/src/charts/cost-chart.tsx
+++ b/packages/ui/src/charts/cost-chart.tsx
@@ -56,12 +56,15 @@ export function CostChart({ data }: CostChartProps) {
           />
           <Tooltip
             contentStyle={{
-              backgroundColor: 'var(--card)',
+              backgroundColor: 'var(--popover)',
               border: '1px solid var(--border)',
               borderRadius: '8px',
               fontSize: '12px',
-              color: 'var(--card-foreground)',
+              color: 'var(--popover-foreground)',
+              boxShadow: '0 8px 24px rgba(0,0,0,0.35)',
             }}
+            labelStyle={{ color: 'var(--popover-foreground)', fontWeight: 600 }}
+            itemStyle={{ color: 'var(--popover-foreground)' }}
             formatter={(v: number) => formatCostKrw(v)}
           />
           <Area
@@ -97,12 +100,15 @@ export function CostChart({ data }: CostChartProps) {
         />
         <Tooltip
           contentStyle={{
-            backgroundColor: 'var(--card)',
+            backgroundColor: 'var(--popover)',
             border: '1px solid var(--border)',
             borderRadius: '8px',
             fontSize: '12px',
-            color: 'var(--card-foreground)',
+            color: 'var(--popover-foreground)',
+            boxShadow: '0 8px 24px rgba(0,0,0,0.35)',
           }}
+          labelStyle={{ color: 'var(--popover-foreground)', fontWeight: 600 }}
+          itemStyle={{ color: 'var(--popover-foreground)' }}
           formatter={(v: number) => formatCostKrw(v)}
         />
         {models.map((model, i) => (

--- a/packages/ui/src/charts/peak-hours.tsx
+++ b/packages/ui/src/charts/peak-hours.tsx
@@ -40,12 +40,15 @@ export function PeakHours({ data }: PeakHoursProps) {
         />
         <Tooltip
           contentStyle={{
-            backgroundColor: 'var(--card)',
+            backgroundColor: 'var(--popover)',
             border: '1px solid var(--border)',
             borderRadius: '8px',
             fontSize: '12px',
-            color: 'var(--card-foreground)',
+            color: 'var(--popover-foreground)',
+            boxShadow: '0 8px 24px rgba(0,0,0,0.35)',
           }}
+          labelStyle={{ color: 'var(--popover-foreground)', fontWeight: 600 }}
+          itemStyle={{ color: 'var(--popover-foreground)' }}
         />
         <Bar dataKey="messages" fill="var(--chart-1)" radius={[3, 3, 0, 0]} />
       </BarChart>

--- a/packages/ui/src/charts/project-cost-chart.tsx
+++ b/packages/ui/src/charts/project-cost-chart.tsx
@@ -36,12 +36,15 @@ export function ProjectCostChart({ data }: ProjectCostChartProps) {
         />
         <Tooltip
           contentStyle={{
-            backgroundColor: 'var(--card)',
+            backgroundColor: 'var(--popover)',
             border: '1px solid var(--border)',
             borderRadius: '8px',
             fontSize: '12px',
-            color: 'var(--card-foreground)',
+            color: 'var(--popover-foreground)',
+            boxShadow: '0 8px 24px rgba(0,0,0,0.35)',
           }}
+          labelStyle={{ color: 'var(--popover-foreground)', fontWeight: 600 }}
+          itemStyle={{ color: 'var(--popover-foreground)' }}
           formatter={(v: number, _name: string, props: { payload?: ProjectCostItem }) => [
             formatCost(v),
             props.payload?.fullName ?? props.payload?.name ?? '비용',

--- a/packages/ui/src/charts/usage-over-time.tsx
+++ b/packages/ui/src/charts/usage-over-time.tsx
@@ -77,12 +77,15 @@ export function UsageOverTime({ data }: UsageOverTimeProps) {
           />
           <Tooltip
             contentStyle={{
-              backgroundColor: 'var(--card)',
+              backgroundColor: 'var(--popover)',
               border: '1px solid var(--border)',
               borderRadius: '8px',
               fontSize: '12px',
-              color: 'var(--card-foreground)',
+              color: 'var(--popover-foreground)',
+              boxShadow: '0 8px 24px rgba(0,0,0,0.35)',
             }}
+            labelStyle={{ color: 'var(--popover-foreground)', fontWeight: 600 }}
+            itemStyle={{ color: 'var(--popover-foreground)' }}
             formatter={(v: number) => [
               activeMetric === 'cost' ? formatCostKrw(v) : v,
               metric.label,

--- a/packages/ui/src/components/ui/card.tsx
+++ b/packages/ui/src/components/ui/card.tsx
@@ -6,7 +6,7 @@ const Card = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
   ({ className, ...props }, ref) => (
     <div
       ref={ref}
-      className={cn('rounded-xl border bg-card text-card-foreground shadow', className)}
+      className={cn('card-glass rounded-xl border text-card-foreground transition-colors duration-200', className)}
       {...props}
     />
   ),

--- a/packages/ui/src/components/ui/dropdown-menu.tsx
+++ b/packages/ui/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,252 @@
+import * as React from "react"
+import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu"
+import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react"
+
+import { cn } from "../../lib/utils"
+
+function DropdownMenu({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
+  return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />
+}
+
+function DropdownMenuPortal({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Portal>) {
+  return (
+    <DropdownMenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />
+  )
+}
+
+function DropdownMenuTrigger({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
+  return (
+    <DropdownMenuPrimitive.Trigger
+      data-slot="dropdown-menu-trigger"
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuContent({
+  className,
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
+  return (
+    <DropdownMenuPrimitive.Portal>
+      <DropdownMenuPrimitive.Content
+        data-slot="dropdown-menu-content"
+        sideOffset={sideOffset}
+        className={cn(
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] overflow-hidden rounded-md border shadow-md",
+          className
+        )}
+        {...props}
+      />
+    </DropdownMenuPrimitive.Portal>
+  )
+}
+
+function DropdownMenuGroup({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Group>) {
+  return (
+    <DropdownMenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />
+  )
+}
+
+function DropdownMenuItem({
+  className,
+  inset,
+  variant = "default",
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Item> & {
+  inset?: boolean
+  variant?: "default" | "destructive"
+}) {
+  return (
+    <DropdownMenuPrimitive.Item
+      data-slot="dropdown-menu-item"
+      data-inset={inset}
+      data-variant={variant}
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden transition-colors data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Separator>) {
+  return (
+    <DropdownMenuPrimitive.Separator
+      data-slot="dropdown-menu-separator"
+      className={cn("bg-border -mx-1 my-1 h-px", className)}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuLabel({
+  className,
+  inset,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Label> & {
+  inset?: boolean
+}) {
+  return (
+    <DropdownMenuPrimitive.Label
+      data-slot="dropdown-menu-label"
+      data-inset={inset}
+      className={cn(
+        "px-2 py-1.5 text-xs font-semibold data-[inset]:pl-8",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.CheckboxItem>) {
+  return (
+    <DropdownMenuPrimitive.CheckboxItem
+      data-slot="dropdown-menu-checkbox-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default select-none items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden transition-colors data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+        className
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.CheckboxItem>
+  )
+}
+
+function DropdownMenuRadioGroup({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioGroup>) {
+  return (
+    <DropdownMenuPrimitive.RadioGroup
+      data-slot="dropdown-menu-radio-group"
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuRadioItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioItem>) {
+  return (
+    <DropdownMenuPrimitive.RadioItem
+      data-slot="dropdown-menu-radio-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default select-none items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden transition-colors data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CircleIcon className="size-2 fill-current" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.RadioItem>
+  )
+}
+
+function DropdownMenuSub({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Sub>) {
+  return <DropdownMenuPrimitive.Sub data-slot="dropdown-menu-sub" {...props} />
+}
+
+function DropdownMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubTrigger> & {
+  inset?: boolean
+}) {
+  return (
+    <DropdownMenuPrimitive.SubTrigger
+      data-slot="dropdown-menu-sub-trigger"
+      data-inset={inset}
+      className={cn(
+        "focus:bg-accent data-[state=open]:bg-accent flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRightIcon className="ml-auto size-4" />
+    </DropdownMenuPrimitive.SubTrigger>
+  )
+}
+
+function DropdownMenuSubContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
+  return (
+    <DropdownMenuPrimitive.SubContent
+      data-slot="dropdown-menu-sub-content"
+      className={cn(
+        "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] overflow-hidden rounded-md border shadow-lg",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuShortcut({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLSpanElement>) {
+  return (
+    <span
+      data-slot="dropdown-menu-shortcut"
+      className={cn("ml-auto text-xs tracking-widest opacity-60", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  DropdownMenu,
+  DropdownMenuPortal,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuLabel,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
+  DropdownMenuShortcut,
+}

--- a/packages/ui/src/components/ui/sheet.tsx
+++ b/packages/ui/src/components/ui/sheet.tsx
@@ -1,0 +1,143 @@
+"use client"
+
+import * as React from "react"
+import { XIcon } from "lucide-react"
+import * as SheetPrimitive from "@radix-ui/react-dialog"
+
+import { cn } from "../../lib/utils"
+
+function Sheet({ ...props }: React.ComponentProps<typeof SheetPrimitive.Root>) {
+  return <SheetPrimitive.Root data-slot="sheet" {...props} />
+}
+
+function SheetTrigger({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Trigger>) {
+  return <SheetPrimitive.Trigger data-slot="sheet-trigger" {...props} />
+}
+
+function SheetClose({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Close>) {
+  return <SheetPrimitive.Close data-slot="sheet-close" {...props} />
+}
+
+function SheetPortal({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Portal>) {
+  return <SheetPrimitive.Portal data-slot="sheet-portal" {...props} />
+}
+
+function SheetOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Overlay>) {
+  return (
+    <SheetPrimitive.Overlay
+      data-slot="sheet-overlay"
+      className={cn(
+        "fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SheetContent({
+  className,
+  children,
+  side = "right",
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Content> & {
+  side?: "top" | "right" | "bottom" | "left"
+  showCloseButton?: boolean
+}) {
+  return (
+    <SheetPortal>
+      <SheetOverlay />
+      <SheetPrimitive.Content
+        data-slot="sheet-content"
+        className={cn(
+          "fixed z-50 flex flex-col gap-4 bg-background shadow-lg transition ease-in-out data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:animate-in data-[state=open]:duration-500",
+          side === "right" &&
+            "inset-y-0 right-0 h-full w-3/4 border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
+          side === "left" &&
+            "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
+          side === "top" &&
+            "inset-x-0 top-0 h-auto border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
+          side === "bottom" &&
+            "inset-x-0 bottom-0 h-auto border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <SheetPrimitive.Close className="absolute top-4 right-4 rounded-xs opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none data-[state=open]:bg-secondary">
+            <XIcon className="size-4" />
+            <span className="sr-only">Close</span>
+          </SheetPrimitive.Close>
+        )}
+      </SheetPrimitive.Content>
+    </SheetPortal>
+  )
+}
+
+function SheetHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-header"
+      className={cn("flex flex-col gap-1.5 p-4", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-footer"
+      className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Title>) {
+  return (
+    <SheetPrimitive.Title
+      data-slot="sheet-title"
+      className={cn("font-semibold text-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Description>) {
+  return (
+    <SheetPrimitive.Description
+      data-slot="sheet-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Sheet,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetFooter,
+  SheetTitle,
+  SheetDescription,
+}

--- a/packages/ui/src/components/ui/sidebar.tsx
+++ b/packages/ui/src/components/ui/sidebar.tsx
@@ -1,0 +1,726 @@
+"use client"
+
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { PanelLeftIcon } from "lucide-react"
+import { Slot } from "@radix-ui/react-slot"
+
+import { useIsMobile } from "../../hooks/use-mobile"
+import { cn } from "../../lib/utils"
+import { Button } from "./button"
+import { Input } from "./input"
+import { Separator } from "./separator"
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "./sheet"
+import { Skeleton } from "./skeleton"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "./tooltip"
+
+const SIDEBAR_COOKIE_NAME = "sidebar_state"
+const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7
+const SIDEBAR_WIDTH = "16rem"
+const SIDEBAR_WIDTH_MOBILE = "18rem"
+const SIDEBAR_WIDTH_ICON = "3rem"
+const SIDEBAR_KEYBOARD_SHORTCUT = "b"
+
+type SidebarContextProps = {
+  state: "expanded" | "collapsed"
+  open: boolean
+  setOpen: (open: boolean) => void
+  openMobile: boolean
+  setOpenMobile: (open: boolean) => void
+  isMobile: boolean
+  toggleSidebar: () => void
+}
+
+const SidebarContext = React.createContext<SidebarContextProps | null>(null)
+
+function useSidebar() {
+  const context = React.useContext(SidebarContext)
+  if (!context) {
+    throw new Error("useSidebar must be used within a SidebarProvider.")
+  }
+
+  return context
+}
+
+function SidebarProvider({
+  defaultOpen = true,
+  open: openProp,
+  onOpenChange: setOpenProp,
+  className,
+  style,
+  children,
+  ...props
+}: React.ComponentProps<"div"> & {
+  defaultOpen?: boolean
+  open?: boolean
+  onOpenChange?: (open: boolean) => void
+}) {
+  const isMobile = useIsMobile()
+  const [openMobile, setOpenMobile] = React.useState(false)
+
+  // This is the internal state of the sidebar.
+  // We use openProp and setOpenProp for control from outside the component.
+  const [_open, _setOpen] = React.useState(defaultOpen)
+  const open = openProp ?? _open
+  const setOpen = React.useCallback(
+    (value: boolean | ((value: boolean) => boolean)) => {
+      const openState = typeof value === "function" ? value(open) : value
+      if (setOpenProp) {
+        setOpenProp(openState)
+      } else {
+        _setOpen(openState)
+      }
+
+      // This sets the cookie to keep the sidebar state.
+      document.cookie = `${SIDEBAR_COOKIE_NAME}=${openState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`
+    },
+    [setOpenProp, open]
+  )
+
+  // Helper to toggle the sidebar.
+  const toggleSidebar = React.useCallback(() => {
+    return isMobile ? setOpenMobile((open) => !open) : setOpen((open) => !open)
+  }, [isMobile, setOpen, setOpenMobile])
+
+  // Adds a keyboard shortcut to toggle the sidebar.
+  React.useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (
+        event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
+        (event.metaKey || event.ctrlKey)
+      ) {
+        event.preventDefault()
+        toggleSidebar()
+      }
+    }
+
+    window.addEventListener("keydown", handleKeyDown)
+    return () => window.removeEventListener("keydown", handleKeyDown)
+  }, [toggleSidebar])
+
+  // We add a state so that we can do data-state="expanded" or "collapsed".
+  // This makes it easier to style the sidebar with Tailwind classes.
+  const state = open ? "expanded" : "collapsed"
+
+  const contextValue = React.useMemo<SidebarContextProps>(
+    () => ({
+      state,
+      open,
+      setOpen,
+      isMobile,
+      openMobile,
+      setOpenMobile,
+      toggleSidebar,
+    }),
+    [state, open, setOpen, isMobile, openMobile, setOpenMobile, toggleSidebar]
+  )
+
+  return (
+    <SidebarContext.Provider value={contextValue}>
+      <TooltipProvider delayDuration={0}>
+        <div
+          data-slot="sidebar-wrapper"
+          style={
+            {
+              "--sidebar-width": SIDEBAR_WIDTH,
+              "--sidebar-width-icon": SIDEBAR_WIDTH_ICON,
+              ...style,
+            } as React.CSSProperties
+          }
+          className={cn(
+            "group/sidebar-wrapper flex min-h-svh w-full has-data-[variant=inset]:bg-sidebar",
+            className
+          )}
+          {...props}
+        >
+          {children}
+        </div>
+      </TooltipProvider>
+    </SidebarContext.Provider>
+  )
+}
+
+function Sidebar({
+  side = "left",
+  variant = "sidebar",
+  collapsible = "offcanvas",
+  className,
+  children,
+  ...props
+}: React.ComponentProps<"div"> & {
+  side?: "left" | "right"
+  variant?: "sidebar" | "floating" | "inset"
+  collapsible?: "offcanvas" | "icon" | "none"
+}) {
+  const { isMobile, state, openMobile, setOpenMobile } = useSidebar()
+
+  if (collapsible === "none") {
+    return (
+      <div
+        data-slot="sidebar"
+        className={cn(
+          "flex h-full w-(--sidebar-width) flex-col bg-sidebar text-sidebar-foreground",
+          className
+        )}
+        {...props}
+      >
+        {children}
+      </div>
+    )
+  }
+
+  if (isMobile) {
+    return (
+      <Sheet open={openMobile} onOpenChange={setOpenMobile} {...props}>
+        <SheetContent
+          data-sidebar="sidebar"
+          data-slot="sidebar"
+          data-mobile="true"
+          className="w-(--sidebar-width) bg-sidebar p-0 text-sidebar-foreground [&>button]:hidden"
+          style={
+            {
+              "--sidebar-width": SIDEBAR_WIDTH_MOBILE,
+            } as React.CSSProperties
+          }
+          side={side}
+        >
+          <SheetHeader className="sr-only">
+            <SheetTitle>Sidebar</SheetTitle>
+            <SheetDescription>Displays the mobile sidebar.</SheetDescription>
+          </SheetHeader>
+          <div className="flex h-full w-full flex-col">{children}</div>
+        </SheetContent>
+      </Sheet>
+    )
+  }
+
+  return (
+    <div
+      className="group peer hidden text-sidebar-foreground md:block"
+      data-state={state}
+      data-collapsible={state === "collapsed" ? collapsible : ""}
+      data-variant={variant}
+      data-side={side}
+      data-slot="sidebar"
+    >
+      {/* This is what handles the sidebar gap on desktop */}
+      <div
+        data-slot="sidebar-gap"
+        className={cn(
+          "relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear",
+          "group-data-[collapsible=offcanvas]:w-0",
+          "group-data-[side=right]:rotate-180",
+          variant === "floating" || variant === "inset"
+            ? "group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4)))]"
+            : "group-data-[collapsible=icon]:w-(--sidebar-width-icon)"
+        )}
+      />
+      <div
+        data-slot="sidebar-container"
+        className={cn(
+          "fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear md:flex",
+          side === "left"
+            ? "left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]"
+            : "right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]",
+          // Adjust the padding for floating and inset variants.
+          variant === "floating" || variant === "inset"
+            ? "p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4))+2px)]"
+            : "group-data-[collapsible=icon]:w-(--sidebar-width-icon) group-data-[side=left]:border-r group-data-[side=right]:border-l",
+          className
+        )}
+        {...props}
+      >
+        <div
+          data-sidebar="sidebar"
+          data-slot="sidebar-inner"
+          className="flex h-full w-full flex-col bg-sidebar group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:border-sidebar-border group-data-[variant=floating]:shadow-sm"
+        >
+          {children}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function SidebarTrigger({
+  className,
+  onClick,
+  ...props
+}: React.ComponentProps<typeof Button>) {
+  const { toggleSidebar } = useSidebar()
+
+  return (
+    <Button
+      data-sidebar="trigger"
+      data-slot="sidebar-trigger"
+      variant="ghost"
+      size="icon"
+      className={cn("size-7", className)}
+      onClick={(event) => {
+        onClick?.(event)
+        toggleSidebar()
+      }}
+      {...props}
+    >
+      <PanelLeftIcon />
+      <span className="sr-only">Toggle Sidebar</span>
+    </Button>
+  )
+}
+
+function SidebarRail({ className, ...props }: React.ComponentProps<"button">) {
+  const { toggleSidebar } = useSidebar()
+
+  return (
+    <button
+      data-sidebar="rail"
+      data-slot="sidebar-rail"
+      aria-label="Toggle Sidebar"
+      tabIndex={-1}
+      onClick={toggleSidebar}
+      title="Toggle Sidebar"
+      className={cn(
+        "absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] hover:after:bg-sidebar-border sm:flex",
+        "in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize",
+        "[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize",
+        "group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full hover:group-data-[collapsible=offcanvas]:bg-sidebar",
+        "[[data-side=left][data-collapsible=offcanvas]_&]:-right-2",
+        "[[data-side=right][data-collapsible=offcanvas]_&]:-left-2",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
+  return (
+    <main
+      data-slot="sidebar-inset"
+      className={cn(
+        "relative flex w-full flex-1 flex-col bg-background",
+        "md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SidebarInput({
+  className,
+  ...props
+}: React.ComponentProps<typeof Input>) {
+  return (
+    <Input
+      data-slot="sidebar-input"
+      data-sidebar="input"
+      className={cn("h-8 w-full bg-background shadow-none", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-header"
+      data-sidebar="header"
+      className={cn("flex flex-col gap-2 p-2", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-footer"
+      data-sidebar="footer"
+      className={cn("flex flex-col gap-2 p-2", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof Separator>) {
+  return (
+    <Separator
+      data-slot="sidebar-separator"
+      data-sidebar="separator"
+      className={cn("mx-2 w-auto bg-sidebar-border", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-content"
+      data-sidebar="content"
+      className={cn(
+        "flex min-h-0 flex-1 flex-col gap-2 overflow-auto group-data-[collapsible=icon]:overflow-hidden",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SidebarGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-group"
+      data-sidebar="group"
+      className={cn("relative flex w-full min-w-0 flex-col p-2", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarGroupLabel({
+  className,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"div"> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot : "div"
+
+  return (
+    <Comp
+      data-slot="sidebar-group-label"
+      data-sidebar="group-label"
+      className={cn(
+        "flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium text-sidebar-foreground/70 ring-sidebar-ring outline-hidden transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+        "group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SidebarGroupAction({
+  className,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"button"> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot : "button"
+
+  return (
+    <Comp
+      data-slot="sidebar-group-action"
+      data-sidebar="group-action"
+      className={cn(
+        "absolute top-3.5 right-3 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground ring-sidebar-ring outline-hidden transition-transform hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+        // Increases the hit area of the button on mobile.
+        "after:absolute after:-inset-2 md:after:hidden",
+        "group-data-[collapsible=icon]:hidden",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SidebarGroupContent({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-group-content"
+      data-sidebar="group-content"
+      className={cn("w-full text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarMenu({ className, ...props }: React.ComponentProps<"ul">) {
+  return (
+    <ul
+      data-slot="sidebar-menu"
+      data-sidebar="menu"
+      className={cn("flex w-full min-w-0 flex-col gap-1", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarMenuItem({ className, ...props }: React.ComponentProps<"li">) {
+  return (
+    <li
+      data-slot="sidebar-menu-item"
+      data-sidebar="menu-item"
+      className={cn("group/menu-item relative", className)}
+      {...props}
+    />
+  )
+}
+
+const sidebarMenuButtonVariants = cva(
+  "peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm ring-sidebar-ring outline-hidden transition-[width,height,padding] group-has-data-[sidebar=menu-action]/menu-item:pr-8 group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
+  {
+    variants: {
+      variant: {
+        default: "hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
+        outline:
+          "bg-background shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))]",
+      },
+      size: {
+        default: "h-8 text-sm",
+        sm: "h-7 text-xs",
+        lg: "h-12 text-sm group-data-[collapsible=icon]:p-0!",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+function SidebarMenuButton({
+  asChild = false,
+  isActive = false,
+  variant = "default",
+  size = "default",
+  tooltip,
+  className,
+  ...props
+}: React.ComponentProps<"button"> & {
+  asChild?: boolean
+  isActive?: boolean
+  tooltip?: string | React.ComponentProps<typeof TooltipContent>
+} & VariantProps<typeof sidebarMenuButtonVariants>) {
+  const Comp = asChild ? Slot : "button"
+  const { isMobile, state } = useSidebar()
+
+  const button = (
+    <Comp
+      data-slot="sidebar-menu-button"
+      data-sidebar="menu-button"
+      data-size={size}
+      data-active={isActive}
+      className={cn(sidebarMenuButtonVariants({ variant, size }), className)}
+      {...props}
+    />
+  )
+
+  if (!tooltip) {
+    return button
+  }
+
+  if (typeof tooltip === "string") {
+    tooltip = {
+      children: tooltip,
+    }
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{button}</TooltipTrigger>
+      <TooltipContent
+        side="right"
+        align="center"
+        hidden={state !== "collapsed" || isMobile}
+        {...tooltip}
+      />
+    </Tooltip>
+  )
+}
+
+function SidebarMenuAction({
+  className,
+  asChild = false,
+  showOnHover = false,
+  ...props
+}: React.ComponentProps<"button"> & {
+  asChild?: boolean
+  showOnHover?: boolean
+}) {
+  const Comp = asChild ? Slot : "button"
+
+  return (
+    <Comp
+      data-slot="sidebar-menu-action"
+      data-sidebar="menu-action"
+      className={cn(
+        "absolute top-1.5 right-1 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground ring-sidebar-ring outline-hidden transition-transform peer-hover/menu-button:text-sidebar-accent-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+        // Increases the hit area of the button on mobile.
+        "after:absolute after:-inset-2 md:after:hidden",
+        "peer-data-[size=sm]/menu-button:top-1",
+        "peer-data-[size=default]/menu-button:top-1.5",
+        "peer-data-[size=lg]/menu-button:top-2.5",
+        "group-data-[collapsible=icon]:hidden",
+        showOnHover &&
+          "group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 peer-data-[active=true]/menu-button:text-sidebar-accent-foreground data-[state=open]:opacity-100 md:opacity-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SidebarMenuBadge({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-menu-badge"
+      data-sidebar="menu-badge"
+      className={cn(
+        "pointer-events-none absolute right-1 flex h-5 min-w-5 items-center justify-center rounded-md px-1 text-xs font-medium text-sidebar-foreground tabular-nums select-none",
+        "peer-hover/menu-button:text-sidebar-accent-foreground peer-data-[active=true]/menu-button:text-sidebar-accent-foreground",
+        "peer-data-[size=sm]/menu-button:top-1",
+        "peer-data-[size=default]/menu-button:top-1.5",
+        "peer-data-[size=lg]/menu-button:top-2.5",
+        "group-data-[collapsible=icon]:hidden",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SidebarMenuSkeleton({
+  className,
+  showIcon = false,
+  ...props
+}: React.ComponentProps<"div"> & {
+  showIcon?: boolean
+}) {
+  // Random width between 50 to 90%.
+  const width = React.useMemo(() => {
+    return `${Math.floor(Math.random() * 40) + 50}%`
+  }, [])
+
+  return (
+    <div
+      data-slot="sidebar-menu-skeleton"
+      data-sidebar="menu-skeleton"
+      className={cn("flex h-8 items-center gap-2 rounded-md px-2", className)}
+      {...props}
+    >
+      {showIcon && (
+        <Skeleton
+          className="size-4 rounded-md"
+          data-sidebar="menu-skeleton-icon"
+        />
+      )}
+      <Skeleton
+        className="h-4 max-w-(--skeleton-width) flex-1"
+        data-sidebar="menu-skeleton-text"
+        style={
+          {
+            "--skeleton-width": width,
+          } as React.CSSProperties
+        }
+      />
+    </div>
+  )
+}
+
+function SidebarMenuSub({ className, ...props }: React.ComponentProps<"ul">) {
+  return (
+    <ul
+      data-slot="sidebar-menu-sub"
+      data-sidebar="menu-sub"
+      className={cn(
+        "mx-3.5 flex min-w-0 translate-x-px flex-col gap-1 border-l border-sidebar-border px-2.5 py-0.5",
+        "group-data-[collapsible=icon]:hidden",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SidebarMenuSubItem({
+  className,
+  ...props
+}: React.ComponentProps<"li">) {
+  return (
+    <li
+      data-slot="sidebar-menu-sub-item"
+      data-sidebar="menu-sub-item"
+      className={cn("group/menu-sub-item relative", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarMenuSubButton({
+  asChild = false,
+  size = "md",
+  isActive = false,
+  className,
+  ...props
+}: React.ComponentProps<"a"> & {
+  asChild?: boolean
+  size?: "sm" | "md"
+  isActive?: boolean
+}) {
+  const Comp = asChild ? Slot : "a"
+
+  return (
+    <Comp
+      data-slot="sidebar-menu-sub-button"
+      data-sidebar="menu-sub-button"
+      data-size={size}
+      data-active={isActive}
+      className={cn(
+        "flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 text-sidebar-foreground ring-sidebar-ring outline-hidden hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0 [&>svg]:text-sidebar-accent-foreground",
+        "data-[active=true]:bg-sidebar-accent data-[active=true]:text-sidebar-accent-foreground",
+        size === "sm" && "text-xs",
+        size === "md" && "text-sm",
+        "group-data-[collapsible=icon]:hidden",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarGroup,
+  SidebarGroupAction,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarInput,
+  SidebarInset,
+  SidebarMenu,
+  SidebarMenuAction,
+  SidebarMenuBadge,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarMenuSkeleton,
+  SidebarMenuSub,
+  SidebarMenuSubButton,
+  SidebarMenuSubItem,
+  SidebarProvider,
+  SidebarRail,
+  SidebarSeparator,
+  SidebarTrigger,
+  useSidebar,
+}

--- a/packages/ui/src/components/ui/skeleton.tsx
+++ b/packages/ui/src/components/ui/skeleton.tsx
@@ -1,0 +1,13 @@
+import { cn } from "../../lib/utils"
+
+function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={cn("animate-pulse rounded-md bg-accent", className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }

--- a/packages/ui/src/globals.css
+++ b/packages/ui/src/globals.css
@@ -62,72 +62,72 @@
 }
 
 :root {
-  --radius: 0.75rem;
-  --background: #FAF9F6;
-  --foreground: #1a1a1a;
-  --card: #FFFFFF;
-  --card-foreground: #1a1a1a;
+  --radius: 0.625rem;
+  --background: #F7F6F2;
+  --foreground: #0D0D0F;
+  --card: rgba(255, 255, 255, 0.85);
+  --card-foreground: #0D0D0F;
   --popover: #FFFFFF;
-  --popover-foreground: #1a1a1a;
-  --primary: #D4764E;
+  --popover-foreground: #0D0D0F;
+  --primary: #C4643A;
   --primary-foreground: #FFFFFF;
-  --secondary: #F5F0EB;
-  --secondary-foreground: #1a1a1a;
-  --muted: #F5F0EB;
-  --muted-foreground: #6B6B6B;
-  --accent: #F5F0EB;
-  --accent-foreground: #1a1a1a;
+  --secondary: #EDE9E3;
+  --secondary-foreground: #0D0D0F;
+  --muted: #EDE9E3;
+  --muted-foreground: #6E6B65;
+  --accent: #EDE9E3;
+  --accent-foreground: #0D0D0F;
   --destructive: oklch(0.577 0.245 27.325);
-  --border: #E8E4DF;
-  --input: #E8E4DF;
-  --ring: #D4764E;
-  --chart-1: #D4764E;
-  --chart-2: #6B8AE6;
-  --chart-3: #5CB87A;
-  --chart-4: #E6C06B;
-  --chart-5: #9B6BE6;
-  --sidebar: #FFFFFF;
-  --sidebar-foreground: #1a1a1a;
-  --sidebar-primary: #D4764E;
+  --border: rgba(0, 0, 0, 0.09);
+  --input: #E5E1DB;
+  --ring: #C4643A;
+  --chart-1: #C4643A;
+  --chart-2: #3D7BA8;
+  --chart-3: #3D8F65;
+  --chart-4: #A07830;
+  --chart-5: #7058A0;
+  --sidebar: rgba(255, 255, 255, 0.7);
+  --sidebar-foreground: #0D0D0F;
+  --sidebar-primary: #C4643A;
   --sidebar-primary-foreground: #FFFFFF;
-  --sidebar-accent: #F5F0EB;
-  --sidebar-accent-foreground: #1a1a1a;
-  --sidebar-border: #E8E4DF;
-  --sidebar-ring: #D4764E;
+  --sidebar-accent: #EDE9E3;
+  --sidebar-accent-foreground: #0D0D0F;
+  --sidebar-border: rgba(0, 0, 0, 0.08);
+  --sidebar-ring: #C4643A;
 }
 
 .dark {
-  --background: #1C1C1E;
-  --foreground: #F8F8F7;
-  --card: #2C2C2E;
-  --card-foreground: #F8F8F7;
-  --popover: #2C2C2E;
-  --popover-foreground: #F8F8F7;
-  --primary: #E8956E;
-  --primary-foreground: #1C1C1E;
-  --secondary: #3A3A3C;
-  --secondary-foreground: #F8F8F7;
-  --muted: #3A3A3C;
-  --muted-foreground: #B0AFA8;
-  --accent: #3A3A3C;
-  --accent-foreground: #F8F8F7;
-  --destructive: oklch(0.704 0.191 22.216);
-  --border: #3A3A3C;
-  --input: #3A3A3C;
-  --ring: #E8956E;
-  --chart-1: #E8956E;
-  --chart-2: #7B9AE6;
-  --chart-3: #6CC88A;
-  --chart-4: #F0D07B;
-  --chart-5: #AB7BF6;
-  --sidebar: #2C2C2E;
-  --sidebar-foreground: #F8F8F7;
-  --sidebar-primary: #E8956E;
-  --sidebar-primary-foreground: #1C1C1E;
-  --sidebar-accent: #3A3A3C;
-  --sidebar-accent-foreground: #F8F8F7;
-  --sidebar-border: #3A3A3C;
-  --sidebar-ring: #E8956E;
+  --background: #07070A;
+  --foreground: #EDEBE7;
+  --card: rgba(255, 255, 255, 0.035);
+  --card-foreground: #EDEBE7;
+  --popover: #18181C;
+  --popover-foreground: #EDEBE7;
+  --primary: #E8834E;
+  --primary-foreground: #07070A;
+  --secondary: #1C1C21;
+  --secondary-foreground: #EDEBE7;
+  --muted: #18181C;
+  --muted-foreground: #72706C;
+  --accent: #1C1C21;
+  --accent-foreground: #EDEBE7;
+  --destructive: oklch(0.65 0.22 22);
+  --border: rgba(255, 255, 255, 0.07);
+  --input: #1C1C21;
+  --ring: #E8834E;
+  --chart-1: #E8834E;
+  --chart-2: #64A0C8;
+  --chart-3: #5BAF82;
+  --chart-4: #D4A050;
+  --chart-5: #A07EC8;
+  --sidebar: rgba(255, 255, 255, 0.025);
+  --sidebar-foreground: #EDEBE7;
+  --sidebar-primary: #E8834E;
+  --sidebar-primary-foreground: #07070A;
+  --sidebar-accent: rgba(255, 255, 255, 0.05);
+  --sidebar-accent-foreground: #EDEBE7;
+  --sidebar-border: rgba(255, 255, 255, 0.06);
+  --sidebar-ring: #E8834E;
 }
 
 @layer base {
@@ -139,7 +139,56 @@
   }
 }
 
-::-webkit-scrollbar { width: 6px; height: 6px; }
+/* ─── Background ambient glow ─── */
+.dark body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+  background:
+    radial-gradient(ellipse 60% 45% at 12% 0%, rgba(232, 131, 78, 0.09) 0%, transparent 65%),
+    radial-gradient(ellipse 40% 30% at 90% 100%, rgba(100, 160, 200, 0.05) 0%, transparent 60%);
+}
+
+body > #root {
+  position: relative;
+  z-index: 1;
+}
+
+/* ─── Glass card base ─── */
+.dark .card-glass {
+  background: rgba(255, 255, 255, 0.03);
+  border-color: rgba(255, 255, 255, 0.07);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+}
+.card-glass {
+  background: rgba(255, 255, 255, 0.75);
+  border-color: rgba(0, 0, 0, 0.07);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+}
+
+/* View Transition - circular reveal for theme toggle */
+::view-transition-image-pair(root) {
+  isolation: auto;
+}
+::view-transition-old(root),
+::view-transition-new(root) {
+  animation: none;
+  mix-blend-mode: normal;
+  display: block;
+}
+/* 기본: new가 위 (확장용) */
+::view-transition-old(root) { z-index: 0; }
+::view-transition-new(root) { z-index: 1; }
+
+/* 수축 모드: html에 data-theme-shrink 속성 시 old가 위 */
+html[data-theme-shrink]::view-transition-old(root) { z-index: 1; }
+html[data-theme-shrink]::view-transition-new(root) { z-index: 0; }
+
+::-webkit-scrollbar { width: 4px; height: 4px; }
 ::-webkit-scrollbar-track { background: transparent; }
-::-webkit-scrollbar-thumb { background: var(--border); border-radius: 3px; }
+::-webkit-scrollbar-thumb { background: var(--border); border-radius: 2px; }
 ::-webkit-scrollbar-thumb:hover { background: var(--muted-foreground); }

--- a/packages/ui/src/hooks/use-mobile.ts
+++ b/packages/ui/src/hooks/use-mobile.ts
@@ -1,0 +1,19 @@
+import * as React from "react"
+
+const MOBILE_BREAKPOINT = 768
+
+export function useIsMobile() {
+  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
+
+  React.useEffect(() => {
+    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
+    const onChange = () => {
+      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
+    }
+    mql.addEventListener("change", onChange)
+    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
+    return () => mql.removeEventListener("change", onChange)
+  }, [])
+
+  return !!isMobile
+}

--- a/packages/ui/src/hooks/use-theme.tsx
+++ b/packages/ui/src/hooks/use-theme.tsx
@@ -1,0 +1,124 @@
+import { createContext, useCallback, useContext, useEffect, useRef, useState, type ReactNode } from 'react';
+
+type Theme = 'dark' | 'light';
+
+interface ThemeContextValue {
+  theme: Theme;
+  toggleRef: React.RefObject<HTMLButtonElement | null>;
+  toggle: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue>({
+  theme: 'dark',
+  toggleRef: { current: null },
+  toggle: () => {},
+});
+
+function applyTheme(theme: Theme) {
+  const root = document.documentElement;
+  root.classList.remove('dark', 'light');
+  root.classList.add(theme);
+  try {
+    localStorage.setItem('theme', theme);
+  } catch {}
+}
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setTheme] = useState<Theme>(() => {
+    try {
+      return (localStorage.getItem('theme') as Theme) ?? 'dark';
+    } catch {
+      return 'dark';
+    }
+  });
+
+  const toggleRef = useRef<HTMLButtonElement | null>(null);
+
+  // 초기 테마 적용 (FOUC 방지 - index.html 인라인 스크립트가 이미 처리하지만 안전장치)
+  useEffect(() => {
+    applyTheme(theme);
+  }, []);
+
+  const toggle = useCallback(() => {
+    const next = theme === 'dark' ? 'light' : 'dark';
+
+    // View Transition API 미지원 환경 fallback
+    if (!document.startViewTransition) {
+      applyTheme(next);
+      setTheme(next);
+      return;
+    }
+
+    // 토글 버튼의 화면 좌표 계산
+    const btn = toggleRef.current;
+    const rect = btn?.getBoundingClientRect();
+    const x = rect ? rect.left + rect.width / 2 : window.innerWidth / 2;
+    const y = rect ? rect.top + rect.height / 2 : window.innerHeight / 2;
+
+    // 화면 모서리까지의 최대 반지름
+    const endRadius = Math.hypot(
+      Math.max(x, window.innerWidth - x),
+      Math.max(y, window.innerHeight - y),
+    );
+
+    const transition = document.startViewTransition(() => {
+      applyTheme(next);
+      setTheme(next);
+    });
+
+    const goingDark = next === 'dark';
+
+    // 수축 모드 표시 (CSS z-index 제어용)
+    if (!goingDark) {
+      document.documentElement.setAttribute('data-theme-shrink', '');
+    }
+
+    transition.ready.then(() => {
+      if (goingDark) {
+        // 라이트 → 다크: 새 다크 뷰가 원형으로 확장
+        document.documentElement.animate(
+          {
+            clipPath: [
+              `circle(0px at ${x}px ${y}px)`,
+              `circle(${endRadius}px at ${x}px ${y}px)`,
+            ],
+          },
+          {
+            duration: 680,
+            easing: 'cubic-bezier(0.25, 0, 0.3, 1)',
+            pseudoElement: '::view-transition-new(root)',
+          },
+        );
+      } else {
+        // 다크 → 라이트: 기존 다크 뷰가 원형으로 수축하며 라이트 노출
+        document.documentElement.animate(
+          {
+            clipPath: [
+              `circle(${endRadius}px at ${x}px ${y}px)`,
+              `circle(0px at ${x}px ${y}px)`,
+            ],
+          },
+          {
+            duration: 680,
+            easing: 'cubic-bezier(0.25, 0, 0.3, 1)',
+            pseudoElement: '::view-transition-old(root)',
+          },
+        );
+      }
+    });
+
+    transition.finished.then(() => {
+      document.documentElement.removeAttribute('data-theme-shrink');
+    });
+  }, [theme]);
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleRef, toggle }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  return useContext(ThemeContext);
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -23,14 +23,30 @@ export {
   DialogTrigger,
 } from './components/ui/dialog';
 export { Input } from './components/ui/input';
+export {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+  DropdownMenuGroup,
+} from './components/ui/dropdown-menu';
 export { ScrollArea, ScrollBar } from './components/ui/scroll-area';
 export { Tabs, TabsContent, TabsList, TabsTrigger } from './components/ui/tabs';
 export { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from './components/ui/tooltip';
 
 // Layout
-export { Sidebar } from './layout/sidebar';
+export { AppSidebar, Sidebar } from './layout/sidebar';
 export { StatCard } from './layout/stat-card';
 export { CostDisplay } from './layout/cost-display';
+
+// Sidebar primitives (shadcn)
+export {
+  SidebarProvider,
+  SidebarTrigger,
+  SidebarInset,
+} from './components/ui/sidebar';
 
 // Charts
 export { ActivityHeatmap } from './charts/activity-heatmap';
@@ -46,6 +62,7 @@ export { UsageOverTime } from './charts/usage-over-time';
 
 // Hooks / Provider
 export { DataProviderWrapper, useProjects, useStats } from './hooks/use-data';
+export { ThemeProvider, useTheme } from './hooks/use-theme';
 
 // Pages
 export {

--- a/packages/ui/src/layout/sidebar.tsx
+++ b/packages/ui/src/layout/sidebar.tsx
@@ -3,15 +3,41 @@ import { type ReactNode } from 'react';
 import { Link, useRouterState } from '@tanstack/react-router';
 
 import {
+  ChevronsUpDown,
   DollarSign,
   FolderOpen,
+  Github,
   LayoutDashboard,
+  Moon,
   Radio,
   Settings,
+  Sun,
   Wand2,
   Zap,
 } from 'lucide-react';
 
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '../components/ui/dropdown-menu';
+
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarGroup,
+  SidebarHeader,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarSeparator,
+  useSidebar,
+} from '../components/ui/sidebar';
+import { useTheme } from '../hooks/use-theme';
 import { cn } from '../lib/utils';
 
 interface NavItem {
@@ -31,75 +57,155 @@ const navItems: NavItem[] = [
   { href: '/data', label: '설정', icon: <Settings className="h-4 w-4" /> },
 ];
 
-export function Sidebar() {
+function AppSidebarInner() {
   const routerState = useRouterState();
   const currentPath = routerState.location.pathname;
+  const { theme, toggle, toggleRef } = useTheme();
+  const { open } = useSidebar();
 
   return (
-    <div className="fixed left-0 top-0 h-screen w-60 bg-card border-r border-border flex flex-col">
-      {/* Logo */}
-      <div className="flex items-center gap-2.5 px-5 py-5 border-b border-border">
-        <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary/10">
-          <Zap className="h-4 w-4 text-primary" />
+    <Sidebar collapsible="icon" className="h-svh border-r border-sidebar-border">
+      {/* Top accent line */}
+      <div className="h-[2px] w-full bg-primary shrink-0" />
+
+      <SidebarHeader className="px-3 py-4">
+        <div className="flex items-center gap-2 overflow-hidden">
+          <div className="flex h-7 w-7 items-center justify-center rounded bg-primary/15 shrink-0">
+            <Zap className="h-3.5 w-3.5 text-primary" />
+          </div>
+          <div
+            className="overflow-hidden whitespace-nowrap transition-[max-width,opacity] duration-200 ease-linear"
+            style={{ maxWidth: open ? '160px' : 0, opacity: open ? 1 : 0 }}
+          >
+            <p className="text-[13px] font-semibold tracking-tight leading-none">Claude Studio</p>
+            <p className="text-[10px] text-muted-foreground mt-0.5 tracking-wide uppercase">Analytics</p>
+          </div>
         </div>
-        <div>
-          <p className="text-sm font-semibold">Claude Studio</p>
-          <p className="text-[10px] text-muted-foreground">사용량 분석</p>
-        </div>
-      </div>
+      </SidebarHeader>
 
-      {/* Nav */}
-      <nav className="flex-1 px-3 py-4 space-y-1">
-        {navItems.map((item) => {
-          const isActive =
-            item.href === '/' ? currentPath === '/' : currentPath.startsWith(item.href);
+      <SidebarSeparator />
 
-          return (
-            <Link
-              key={item.href}
-              to={item.href}
-              className={cn(
-                'flex items-center gap-3 rounded-lg px-3 py-2 text-sm transition-colors',
-                isActive
-                  ? 'bg-primary/10 text-primary font-medium'
-                  : 'text-muted-foreground hover:bg-muted hover:text-foreground',
-              )}
-            >
-              {item.icon}
-              {item.label}
-              {item.badge && (
-                <span className="ml-auto flex items-center gap-1.5">
-                  <span className="text-[10px] font-medium px-1.5 py-0.5 rounded bg-primary/15 text-primary leading-none">
-                    {item.badge}
-                  </span>
-                  {item.pulse && (
-                    <span className="flex h-2 w-2">
-                      <span className="animate-ping absolute inline-flex h-2 w-2 rounded-full bg-primary opacity-75" />
-                      <span className="relative inline-flex rounded-full h-2 w-2 bg-primary" />
-                    </span>
-                  )}
-                </span>
-              )}
-            </Link>
-          );
-        })}
-      </nav>
+      <SidebarContent>
+        <SidebarGroup>
+          <SidebarMenu>
+            {navItems.map((item) => {
+              const isActive =
+                item.href === '/' ? currentPath === '/' : currentPath.startsWith(item.href);
 
-      {/* Footer */}
-      <div className="px-5 py-4 border-t border-border flex items-center justify-between">
-        <p className="text-[10px] text-muted-foreground">Claude Studio v1.1.0</p>
-        <a
-          href="https://github.com/FRONT-JB/claude-studio"
-          target="_blank"
-          rel="noreferrer"
-          className="text-muted-foreground hover:text-foreground transition-colors"
-          aria-label="GitHub Repository"
-        >
-          <svg viewBox="0 0 24 24" className="h-3.5 w-3.5" fill="currentColor">
-            <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0 1 12 6.844a9.59 9.59 0 0 1 2.504.337c1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.02 10.02 0 0 0 22 12.017C22 6.484 17.522 2 12 2z" />
-          </svg>
-        </a>
-      </div>
-    </div>
+              return (
+                <SidebarMenuItem key={item.href}>
+                  <SidebarMenuButton
+                    asChild
+                    isActive={isActive}
+                    tooltip={item.label}
+                    className={cn(
+                      'relative',
+                      isActive && 'bg-primary/10 text-primary hover:bg-primary/10 hover:text-primary',
+                    )}
+                  >
+                    <Link to={item.href}>
+                      {isActive && (
+                        <span className="absolute left-0 top-1/2 -translate-y-1/2 h-4 w-0.5 rounded-full bg-primary" />
+                      )}
+                      {item.icon}
+                      <span className="tracking-tight">{item.label}</span>
+                      {item.badge && (
+                        <div
+                          className="ml-auto overflow-hidden transition-[max-width,opacity] duration-200 ease-linear flex items-center gap-1.5 shrink-0"
+                          style={{ maxWidth: open ? '80px' : 0, opacity: open ? 1 : 0 }}
+                        >
+                          <span className="text-[9px] font-semibold px-1.5 py-0.5 rounded-sm bg-primary/15 text-primary leading-none tracking-wide uppercase whitespace-nowrap">
+                            {item.badge}
+                          </span>
+                          {item.pulse && (
+                            <span className="relative flex h-1.5 w-1.5 shrink-0">
+                              <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-primary opacity-60" />
+                              <span className="relative inline-flex rounded-full h-1.5 w-1.5 bg-primary" />
+                            </span>
+                          )}
+                        </div>
+                      )}
+                    </Link>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+              );
+            })}
+          </SidebarMenu>
+        </SidebarGroup>
+      </SidebarContent>
+
+      <SidebarSeparator />
+
+      <SidebarFooter>
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <SidebarMenuButton
+                  size="lg"
+                  tooltip="Claude Studio"
+                  className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
+                >
+                  <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary/15 shrink-0">
+                    <Zap className="h-4 w-4 text-primary" />
+                  </div>
+                  <div className="grid flex-1 text-left text-sm leading-tight">
+                    <span className="truncate font-semibold text-[13px]">Claude Studio</span>
+                    <span className="truncate text-[10px] text-muted-foreground font-mono">v1.1.0</span>
+                  </div>
+                  <ChevronsUpDown className="ml-auto h-4 w-4 text-muted-foreground" />
+                </SidebarMenuButton>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent
+                className="w-[--radix-dropdown-menu-trigger-width] min-w-52 rounded-lg"
+                side="top"
+                align="end"
+                sideOffset={4}
+              >
+                <DropdownMenuLabel className="p-0 font-normal">
+                  <div className="flex items-center gap-2 px-2 py-2">
+                    <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary/15 shrink-0">
+                      <Zap className="h-4 w-4 text-primary" />
+                    </div>
+                    <div className="grid flex-1 text-left text-sm leading-tight">
+                      <span className="truncate font-semibold text-[13px]">Claude Studio</span>
+                      <span className="truncate text-[10px] text-muted-foreground font-mono">v1.1.0</span>
+                    </div>
+                  </div>
+                </DropdownMenuLabel>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem asChild>
+                  <button ref={toggleRef} onClick={toggle} className="w-full gap-2">
+                    {theme === 'dark'
+                      ? <Sun className="h-4 w-4" />
+                      : <Moon className="h-4 w-4" />}
+                    {theme === 'dark' ? '라이트 모드' : '다크 모드'}
+                  </button>
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem asChild>
+                  <a
+                    href="https://github.com/FRONT-JB/claude-studio"
+                    target="_blank"
+                    rel="noreferrer"
+                    className="gap-2"
+                  >
+                    <Github className="h-4 w-4" />
+                    GitHub
+                  </a>
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </SidebarMenuItem>
+        </SidebarMenu>
+      </SidebarFooter>
+    </Sidebar>
   );
 }
+
+export function AppSidebar() {
+  return <AppSidebarInner />;
+}
+
+// 하위 호환성 유지
+export { AppSidebar as Sidebar };

--- a/packages/ui/src/layout/stat-card.tsx
+++ b/packages/ui/src/layout/stat-card.tsx
@@ -1,6 +1,5 @@
 import { type ReactNode } from 'react';
 
-import { Card, CardContent } from '../components/ui/card';
 import { cn } from '../lib/utils';
 
 interface StatCardProps {
@@ -13,35 +12,57 @@ interface StatCardProps {
     label: string;
   };
   className?: string;
+  featured?: boolean;
 }
 
-export function StatCard({ title, value, description, icon, trend, className }: StatCardProps) {
+export function StatCard({ title, value, description, trend, className, featured }: StatCardProps) {
   return (
-    <Card className={cn('border-border/50 shadow-sm', className)}>
-      <CardContent className="p-6">
-        <div className="flex items-start justify-between">
-          <div className="space-y-2">
-            <p className="text-sm text-muted-foreground">{title}</p>
-            <p className="text-2xl font-semibold tracking-tight">{value}</p>
-            {description && <p className="text-xs text-muted-foreground">{description}</p>}
-            {trend && (
-              <div
-                className={cn(
-                  'flex items-center gap-1 text-xs',
-                  trend.value >= 0 ? 'text-green-500' : 'text-red-500',
-                )}
-              >
-                <span>
-                  {trend.value >= 0 ? '+' : ''}
-                  {trend.value}%
-                </span>
-                <span className="text-muted-foreground">{trend.label}</span>
-              </div>
-            )}
+    <div
+      className={cn(
+        'card-glass relative rounded-xl border overflow-hidden transition-all duration-200',
+        'group hover:border-primary/20',
+        className,
+      )}
+    >
+      {/* 좌측 accent bar */}
+      <div className={cn(
+        'absolute left-0 top-0 bottom-0 w-[2px] transition-all duration-300',
+        featured
+          ? 'bg-gradient-to-b from-primary via-primary/60 to-transparent opacity-100'
+          : 'bg-gradient-to-b from-primary/40 via-primary/20 to-transparent opacity-0 group-hover:opacity-100',
+      )} />
+
+      <div className="px-5 pt-5 pb-5 pl-6">
+        <p className="text-[10px] font-semibold text-muted-foreground uppercase tracking-[0.2em] mb-3">
+          {title}
+        </p>
+
+        <p className={cn(
+          'font-bold tracking-tight font-mono leading-none',
+          featured ? 'text-4xl text-primary' : 'text-3xl text-foreground',
+        )}>
+          {value}
+        </p>
+
+        {description && (
+          <p className="text-[11px] text-muted-foreground mt-2.5 leading-relaxed">{description}</p>
+        )}
+
+        {trend && (
+          <div className={cn(
+            'flex items-center gap-1 text-[11px] font-medium mt-2',
+            trend.value >= 0 ? 'text-emerald-500' : 'text-red-400',
+          )}>
+            <span>{trend.value >= 0 ? '+' : ''}{trend.value}%</span>
+            <span className="text-muted-foreground font-normal">{trend.label}</span>
           </div>
-          <div className="rounded-lg bg-primary/10 p-2.5 text-primary">{icon}</div>
-        </div>
-      </CardContent>
-    </Card>
+        )}
+      </div>
+
+      {/* featured 카드 배경 glow */}
+      {featured && (
+        <div className="absolute inset-0 pointer-events-none bg-gradient-to-br from-primary/[0.06] to-transparent" />
+      )}
+    </div>
   );
 }

--- a/packages/ui/src/pages/costs-page.tsx
+++ b/packages/ui/src/pages/costs-page.tsx
@@ -3,13 +3,13 @@ import { useMemo, useState } from 'react';
 import type { DailyUsage } from '@repo/shared';
 import { formatDateShort, formatTokens } from '@repo/shared';
 
-import { DollarSign, Minus, TrendingDown, TrendingUp } from 'lucide-react';
+import { ArrowDown, ArrowUp, DollarSign, Minus, TrendingDown, TrendingUp, Zap } from 'lucide-react';
 
 import { CostChart } from '../charts/cost-chart';
 import { ModelBreakdown } from '../charts/model-breakdown';
 import { ProjectCostChart } from '../charts/project-cost-chart';
 import { UsageOverTime } from '../charts/usage-over-time';
-import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/card';
+import { Card, CardContent, CardHeader } from '../components/ui/card';
 import { useProjects, useStats } from '../hooks/use-data';
 import { StatCard } from '../layout/stat-card';
 import { CostValue } from './cost-value';
@@ -119,19 +119,20 @@ export function CostsPage() {
   if (isLoading) return <PageSpinner />;
   if (!stats) return <div className="text-muted-foreground">데이터가 없습니다</div>;
 
+  const CT = ({ children }: { children: React.ReactNode }) => (
+    <p className="text-xs font-medium uppercase tracking-widest text-muted-foreground">{children}</p>
+  );
+
   return (
-    <div className="space-y-6">
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-2xl font-semibold">비용</h1>
-          <p className="text-muted-foreground text-sm mt-1">토큰 사용량 및 비용 분석</p>
-        </div>
-        <div className="flex gap-1 rounded-lg border border-border/50 p-1">
+    <div className="space-y-4">
+      {/* 기간 필터 */}
+      <div className="flex justify-end">
+        <div className="flex gap-0.5 rounded border border-border p-0.5">
           {PERIOD_OPTIONS.map((opt) => (
             <button
               key={opt.value}
               onClick={() => setPeriod(opt.value)}
-              className={`px-3 py-1.5 rounded-md text-xs font-medium transition-colors ${
+              className={`px-3 py-1 rounded-sm text-[10px] font-medium transition-colors tracking-wide ${
                 period === opt.value
                   ? 'bg-primary/10 text-primary'
                   : 'text-muted-foreground hover:text-foreground'
@@ -143,114 +144,77 @@ export function CostsPage() {
         </div>
       </div>
 
-      <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
-        <StatCard
-          title="총 비용"
-          value={<CostValue cost={totals.cost} />}
-          description={periodDesc}
-          icon={<DollarSign className="h-4 w-4" />}
-        />
-        <StatCard
-          title="입력 토큰"
-          value={formatTokens(totals.inputTokens)}
-          description={periodDesc}
-          icon={<TrendingUp className="h-4 w-4" />}
-        />
-        <StatCard
-          title="출력 토큰"
-          value={formatTokens(totals.outputTokens)}
-          description={periodDesc}
-          icon={<TrendingUp className="h-4 w-4" />}
-        />
-        <StatCard
-          title="총 토큰"
-          value={formatTokens(totals.inputTokens + totals.outputTokens)}
-          description={periodDesc}
-          icon={<TrendingUp className="h-4 w-4" />}
-        />
+      {/* 통계 카드 4열 */}
+      <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+        <StatCard title="총 비용" value={<CostValue cost={totals.cost} />} description={periodDesc} icon={<DollarSign className="h-4 w-4" />} />
+        <StatCard title="입력 토큰" value={formatTokens(totals.inputTokens)} description={periodDesc} icon={<ArrowDown className="h-4 w-4" />} />
+        <StatCard title="출력 토큰" value={formatTokens(totals.outputTokens)} description={periodDesc} icon={<ArrowUp className="h-4 w-4" />} />
+        <StatCard title="총 토큰" value={formatTokens(totals.inputTokens + totals.outputTokens)} description={periodDesc} icon={<Zap className="h-4 w-4" />} />
       </div>
 
-      <div className="grid grid-cols-2 gap-4">
-        <Card className="border-border/50">
-          <CardContent className="p-4">
-            <p className="text-xs text-muted-foreground">이번 달</p>
-            <p className="text-xl font-semibold mt-1">
-              <CostValue cost={thisMonthCost} />
-            </p>
-            <p className="text-xs text-muted-foreground mt-1">{thisMonth}</p>
-          </CardContent>
+      {/* Bento 12열 */}
+      <div className="grid gap-3" style={{ gridTemplateColumns: 'repeat(12, minmax(0, 1fr))' }}>
+
+        {/* 일별 비용 (8칸) */}
+        <Card style={{ gridColumn: 'span 8' }}>
+          <CardHeader className="px-5 pt-5 pb-3"><CT>일별 비용</CT></CardHeader>
+          <CardContent className="px-5 pb-5 pt-0"><CostChart data={filteredDaily} /></CardContent>
         </Card>
-        <Card className="border-border/50">
-          <CardContent className="p-4">
-            <div className="flex items-center justify-between">
-              <p className="text-xs text-muted-foreground">지난 달</p>
-              {monthDiff !== null && (
-                <div
-                  className={`flex items-center gap-0.5 text-xs font-medium ${
-                    monthDiff > 0
-                      ? 'text-red-400'
-                      : monthDiff < 0
-                        ? 'text-green-400'
-                        : 'text-muted-foreground'
-                  }`}
-                >
-                  {monthDiff > 0 ? (
-                    <TrendingUp className="h-3 w-3" />
-                  ) : monthDiff < 0 ? (
-                    <TrendingDown className="h-3 w-3" />
-                  ) : (
-                    <Minus className="h-3 w-3" />
-                  )}
-                  {Math.abs(monthDiff).toFixed(1)}%
-                </div>
-              )}
-            </div>
-            <p className="text-xl font-semibold mt-1">
-              <CostValue cost={lastMonthCost} />
-            </p>
-            <p className="text-xs text-muted-foreground mt-1">{lastMonth}</p>
-          </CardContent>
+
+        {/* 이번 달 / 지난 달 (4칸 세로 스택) */}
+        <div style={{ gridColumn: 'span 4' }} className="flex flex-col gap-3">
+          <Card className="flex-1">
+            <CardContent className="p-5 h-full flex flex-col justify-between">
+              <p className="text-[10px] font-semibold text-muted-foreground uppercase tracking-[0.2em]">이번 달</p>
+              <div>
+                <p className="text-3xl font-bold font-mono tracking-tight leading-none mt-3">
+                  <CostValue cost={thisMonthCost} />
+                </p>
+                <p className="text-[11px] text-muted-foreground mt-2 font-mono">{thisMonth}</p>
+              </div>
+            </CardContent>
+          </Card>
+          <Card className="flex-1">
+            <CardContent className="p-5 h-full flex flex-col justify-between">
+              <div className="flex items-center justify-between">
+                <p className="text-[10px] font-semibold text-muted-foreground uppercase tracking-[0.2em]">지난 달</p>
+                {monthDiff !== null && (
+                  <div className={`flex items-center gap-0.5 text-[11px] font-semibold ${monthDiff > 0 ? 'text-red-400' : monthDiff < 0 ? 'text-emerald-500' : 'text-muted-foreground'}`}>
+                    {monthDiff > 0 ? <TrendingUp className="h-3 w-3" /> : monthDiff < 0 ? <TrendingDown className="h-3 w-3" /> : <Minus className="h-3 w-3" />}
+                    {Math.abs(monthDiff).toFixed(1)}%
+                  </div>
+                )}
+              </div>
+              <div>
+                <p className="text-3xl font-bold font-mono tracking-tight leading-none mt-3">
+                  <CostValue cost={lastMonthCost} />
+                </p>
+                <p className="text-[11px] text-muted-foreground mt-2 font-mono">{lastMonth}</p>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+
+        {/* 시간별 사용량 (7칸) */}
+        <Card style={{ gridColumn: 'span 7' }}>
+          <CardHeader className="px-5 pt-5 pb-3"><CT>시간별 사용량</CT></CardHeader>
+          <CardContent className="px-5 pb-5 pt-0"><UsageOverTime data={filteredDaily} /></CardContent>
         </Card>
+
+        {/* 모델별 분석 (5칸) */}
+        <Card style={{ gridColumn: 'span 5' }}>
+          <CardHeader className="px-5 pt-5 pb-3"><CT>모델별 분석</CT></CardHeader>
+          <CardContent className="px-5 pb-5 pt-0"><ModelBreakdown data={stats.modelBreakdown} /></CardContent>
+        </Card>
+
+        {/* 프로젝트별 비용 순위 (12칸 전체) */}
+        {topProjects.length > 0 && (
+          <Card style={{ gridColumn: 'span 12' }}>
+            <CardHeader className="px-5 pt-5 pb-3"><CT>프로젝트별 비용 순위</CT></CardHeader>
+            <CardContent className="px-5 pb-5 pt-0"><ProjectCostChart data={topProjects} /></CardContent>
+          </Card>
+        )}
       </div>
-
-      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
-        <Card className="border-border/50">
-          <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium">일별 비용</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <CostChart data={filteredDaily} />
-          </CardContent>
-        </Card>
-        <Card className="border-border/50">
-          <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium">모델별 분석</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <ModelBreakdown data={stats.modelBreakdown} />
-          </CardContent>
-        </Card>
-      </div>
-
-      {topProjects.length > 0 && (
-        <Card className="border-border/50">
-          <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium">프로젝트별 비용 순위</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <ProjectCostChart data={topProjects} />
-          </CardContent>
-        </Card>
-      )}
-
-      <Card className="border-border/50">
-        <CardHeader className="pb-2">
-          <CardTitle className="text-sm font-medium">시간별 사용량</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <UsageOverTime data={filteredDaily} />
-        </CardContent>
-      </Card>
     </div>
   );
 }

--- a/packages/ui/src/pages/data-page.tsx
+++ b/packages/ui/src/pages/data-page.tsx
@@ -23,35 +23,28 @@ export function DataPage({ settings }: DataPageProps) {
     : [];
 
   return (
-    <div className="space-y-6">
-      <div>
-        <h1 className="text-2xl font-semibold">설정</h1>
-        <p className="text-muted-foreground text-sm mt-1">
-          로컬 머신의 ~/.claude/ 디렉토리에서 직접 데이터를 읽어옵니다.
-        </p>
-      </div>
-
-      <div className="grid gap-4">
-        <Card className="border-border/50">
-          <CardHeader className="pb-2">
-            <CardTitle className="flex items-center gap-2 text-sm font-medium">
+    <div className="space-y-4">
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+        <Card>
+          <CardHeader className="px-5 pt-5 pb-3">
+            <CardTitle className="flex items-center gap-2 text-[10px] font-semibold uppercase tracking-[0.2em] text-muted-foreground">
               <Bot className="h-4 w-4" />
               현재 모델
             </CardTitle>
           </CardHeader>
-          <CardContent>
-            <p className="text-base font-semibold">{settings?.model ?? '-'}</p>
+          <CardContent className="px-5 pb-5 pt-0">
+            <p className="text-base font-semibold font-mono">{settings?.model ?? '-'}</p>
           </CardContent>
         </Card>
 
-        <Card className="border-border/50">
-          <CardHeader className="pb-2">
-            <CardTitle className="flex items-center gap-2 text-sm font-medium">
+        <Card>
+          <CardHeader className="px-5 pt-5 pb-3">
+            <CardTitle className="flex items-center gap-2 text-[10px] font-semibold uppercase tracking-[0.2em] text-muted-foreground">
               <ShieldCheck className="h-4 w-4" />
               권한 모드
             </CardTitle>
           </CardHeader>
-          <CardContent>
+          <CardContent className="px-5 pb-5 pt-0">
             <p className="text-base font-semibold">
               {settings?.permissions?.defaultMode
                 ? (modeLabel[settings.permissions.defaultMode] ?? settings.permissions.defaultMode)
@@ -60,18 +53,18 @@ export function DataPage({ settings }: DataPageProps) {
           </CardContent>
         </Card>
 
-        <Card className="border-border/50">
-          <CardHeader className="pb-2">
-            <CardTitle className="flex items-center gap-2 text-sm font-medium">
+        <Card className="md:col-span-2 xl:col-span-1">
+          <CardHeader className="px-5 pt-5 pb-3">
+            <CardTitle className="flex items-center gap-2 text-[10px] font-semibold uppercase tracking-[0.2em] text-muted-foreground">
               <Puzzle className="h-4 w-4" />
               활성화된 플러그인
             </CardTitle>
           </CardHeader>
-          <CardContent>
+          <CardContent className="px-5 pb-5 pt-0">
             {plugins.length > 0 ? (
               <div className="flex flex-wrap gap-2">
                 {plugins.map((name) => (
-                  <Badge key={name} variant="secondary" className="text-xs">
+                  <Badge key={name} variant="secondary" className="text-xs font-mono">
                     {name}
                   </Badge>
                 ))}

--- a/packages/ui/src/pages/overview-page.tsx
+++ b/packages/ui/src/pages/overview-page.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 
 import type { DailyUsage } from '@repo/shared';
-import { formatDate, formatDateShort, formatNumber, formatTokens, timeAgo } from '@repo/shared';
+import { formatDateShort, formatNumber, formatTokens, timeAgo } from '@repo/shared';
 
 import { DollarSign, FolderOpen, MessageSquare, Zap } from 'lucide-react';
 
@@ -13,7 +13,7 @@ import { ModelBreakdown } from '../charts/model-breakdown';
 import { PeakHours } from '../charts/peak-hours';
 import { ToolUsageChart } from '../charts/tool-usage';
 import { UsageOverTime } from '../charts/usage-over-time';
-import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/card';
+import { Card, CardContent, CardHeader } from '../components/ui/card';
 import { useStats } from '../hooks/use-data';
 import { StatCard } from '../layout/stat-card';
 import { CostValue } from './cost-value';
@@ -26,6 +26,10 @@ function getDateRangeDesc(dailyUsage: DailyUsage[]): string {
   return `${formatDateShort(dates[0]!)} ~ ${formatDateShort(dates[dates.length - 1]!)}`;
 }
 
+const CL = ({ children }: { children: React.ReactNode }) => (
+  <p className="text-[10px] font-semibold text-muted-foreground uppercase tracking-[0.2em]">{children}</p>
+);
+
 export function OverviewPage() {
   const { data: stats, isLoading } = useStats();
   const [modelView, setModelView] = useState<'cost' | 'tokens'>('cost');
@@ -36,70 +40,68 @@ export function OverviewPage() {
   const dateRangeDesc = getDateRangeDesc(stats.dailyUsage);
 
   return (
-    <div className="space-y-6">
-      <div className="flex items-start justify-between">
-        <div>
-          <h1 className="text-2xl font-semibold">개요</h1>
-          <p className="text-muted-foreground text-sm mt-1">Claude Code 사용량 요약</p>
+    <div className="space-y-3">
+      {/* ── Bento Grid (12열) ── */}
+      <div className="grid gap-3" style={{ gridTemplateColumns: 'repeat(12, minmax(0, 1fr))' }}>
+
+        {/* ── Row 1: Stat Cards (각 3칸) ── */}
+        <div style={{ gridColumn: 'span 3' }}>
+          <StatCard
+            featured
+            title="총 비용"
+            value={<CostValue cost={stats.totalCost} />}
+            description={
+              stats.lifetime?.firstSessionDate
+                ? `${dateRangeDesc} · D+${stats.lifetime.daysActive}`
+                : dateRangeDesc
+            }
+            icon={<DollarSign />}
+          />
         </div>
-        {stats.lifetime?.firstSessionDate && (
-          <div className="flex items-center gap-2 text-sm">
-            <p className="text-muted-foreground">사용 시작일</p>
-            <p className="font-semibold">{formatDate(stats.lifetime.firstSessionDate)}</p>
-            <p className="text-primary">D+{stats.lifetime.daysActive}</p>
-          </div>
-        )}
-      </div>
+        <div style={{ gridColumn: 'span 3' }}>
+          <StatCard
+            title="총 토큰"
+            value={formatTokens(stats.totalTokens)}
+            description={`입력 ${formatTokens(stats.inputTokens)} / 출력 ${formatTokens(stats.outputTokens)}`}
+            icon={<Zap />}
+          />
+        </div>
+        <div style={{ gridColumn: 'span 3' }}>
+          <StatCard
+            title="세션"
+            value={formatNumber(stats.totalSessions)}
+            description={`${stats.totalProjects}개 프로젝트`}
+            icon={<MessageSquare />}
+          />
+        </div>
+        <div style={{ gridColumn: 'span 3' }}>
+          <StatCard
+            title="메시지"
+            value={formatNumber(stats.totalMessages)}
+            description={`툴 호출 ${formatNumber(stats.totalToolCalls)}회`}
+            icon={<FolderOpen />}
+          />
+        </div>
 
-      <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
-        <StatCard
-          title="총 비용"
-          value={<CostValue cost={stats.totalCost} />}
-          description={dateRangeDesc}
-          icon={<DollarSign className="h-4 w-4" />}
-        />
-        <StatCard
-          title="총 토큰"
-          value={formatTokens(stats.totalTokens)}
-          description={`입력 ${formatTokens(stats.inputTokens)} / 출력 ${formatTokens(stats.outputTokens)}`}
-          icon={<Zap className="h-4 w-4" />}
-        />
-        <StatCard
-          title="세션"
-          value={formatNumber(stats.totalSessions)}
-          description={`${stats.totalProjects}개 프로젝트`}
-          icon={<MessageSquare className="h-4 w-4" />}
-        />
-        <StatCard
-          title="메시지"
-          value={formatNumber(stats.totalMessages)}
-          description={`툴 호출 ${formatNumber(stats.totalToolCalls)}회`}
-          icon={<FolderOpen className="h-4 w-4" />}
-        />
-      </div>
-
-      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
-        <Card className="border-border/50">
-          <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium">시간별 사용량</CardTitle>
-          </CardHeader>
-          <CardContent>
+        {/* ── Row 2: 시간별 사용량 (8칸) + 모델별 분석 (4칸) ── */}
+        <Card style={{ gridColumn: 'span 8' }}>
+          <CardHeader className="px-5 pt-5 pb-3"><CL>시간별 사용량</CL></CardHeader>
+          <CardContent className="px-5 pb-5 pt-0">
             <UsageOverTime data={stats.dailyUsage} />
           </CardContent>
         </Card>
-        <Card className="border-border/50">
-          <CardHeader className="pb-2">
+
+        <Card style={{ gridColumn: 'span 4' }}>
+          <CardHeader className="px-5 pt-5 pb-3">
             <div className="flex items-center justify-between">
-              <CardTitle className="text-sm font-medium">모델별 분석</CardTitle>
-              <div className="flex gap-1">
+              <CL>모델별 분석</CL>
+              <div className="flex gap-0.5 rounded border border-border p-0.5">
                 {(['cost', 'tokens'] as const).map((v) => (
                   <button
                     key={v}
                     onClick={() => setModelView(v)}
-                    className={`px-3 py-1 rounded-md text-xs font-medium transition-colors ${
-                      modelView === v
-                        ? 'bg-primary/10 text-primary'
-                        : 'text-muted-foreground hover:text-foreground'
+                    className={`px-2 py-0.5 rounded-sm text-[9px] font-semibold transition-colors tracking-wide uppercase ${
+                      modelView === v ? 'bg-primary/10 text-primary' : 'text-muted-foreground hover:text-foreground'
                     }`}
                   >
                     {v === 'cost' ? '비용' : '토큰'}
@@ -108,102 +110,84 @@ export function OverviewPage() {
               </div>
             </div>
           </CardHeader>
-          <CardContent>
-            <ModelBreakdown
-              data={stats.modelBreakdown}
-              view={modelView}
-              onViewChange={setModelView}
-            />
+          <CardContent className="px-5 pb-5 pt-0">
+            <ModelBreakdown data={stats.modelBreakdown} view={modelView} onViewChange={setModelView} />
           </CardContent>
         </Card>
-        <Card className="border-border/50">
-          <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium">활동 히트맵</CardTitle>
-          </CardHeader>
-          <CardContent>
+
+        {/* ── Row 3: 활동 히트맵 (7칸) + 피크 시간대 (5칸) ── */}
+        <Card style={{ gridColumn: 'span 7' }}>
+          <CardHeader className="px-5 pt-5 pb-3"><CL>활동 히트맵</CL></CardHeader>
+          <CardContent className="px-5 pb-5 pt-0">
             <ActivityHeatmap data={stats.activityData} />
           </CardContent>
         </Card>
-        <Card className="border-border/50">
-          <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium">피크 시간대</CardTitle>
-          </CardHeader>
-          <CardContent>
+
+        <Card style={{ gridColumn: 'span 5' }}>
+          <CardHeader className="px-5 pt-5 pb-3"><CL>피크 시간대</CL></CardHeader>
+          <CardContent className="px-5 pb-5 pt-0">
             <PeakHours data={stats.peakHours} />
           </CardContent>
         </Card>
-      </div>
 
-      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
-        <Card className="border-border/50">
-          <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium">캐시 절약 현황</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <CacheStatsCard data={stats.cacheStats} />
+        {/* ── Row 4: 모델별 일별 비용 (8칸) + 툴 사용 순위 (4칸) ── */}
+        <Card style={{ gridColumn: 'span 8' }}>
+          <CardHeader className="px-5 pt-5 pb-3"><CL>모델별 일별 비용</CL></CardHeader>
+          <CardContent className="px-5 pb-5 pt-0">
+            <CostChart data={stats.dailyUsage} />
           </CardContent>
         </Card>
-        <Card className="border-border/50">
-          <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium">툴 사용 순위</CardTitle>
-          </CardHeader>
-          <CardContent>
+
+        <Card style={{ gridColumn: 'span 4' }}>
+          <CardHeader className="px-5 pt-5 pb-3"><CL>툴 사용 순위</CL></CardHeader>
+          <CardContent className="px-5 pb-5 pt-0">
             <ToolUsageChart data={stats.toolUsage} />
           </CardContent>
         </Card>
+
+        {/* ── Row 5: 캐시 절약 (4칸) + 대화 패턴 (8칸) ── */}
+        <Card style={{ gridColumn: 'span 4' }}>
+          <CardHeader className="px-5 pt-5 pb-3"><CL>캐시 절약 현황</CL></CardHeader>
+          <CardContent className="px-5 pb-5 pt-0">
+            <CacheStatsCard data={stats.cacheStats} />
+          </CardContent>
+        </Card>
+
+        <Card style={{ gridColumn: 'span 8' }}>
+          <CardHeader className="px-5 pt-5 pb-3"><CL>대화 패턴 분석</CL></CardHeader>
+          <CardContent className="px-5 pb-5 pt-0">
+            <ConversationStatsCard data={stats.conversationStats} />
+          </CardContent>
+        </Card>
+
+        {/* ── Row 6: 최근 세션 (12칸 전체, 내부 3열) ── */}
+        <Card style={{ gridColumn: 'span 12' }}>
+          <CardHeader className="px-5 pt-5 pb-3"><CL>최근 세션</CL></CardHeader>
+          <CardContent className="px-5 pb-4 pt-0">
+            <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 divide-y md:divide-y-0 md:divide-x divide-border/40">
+              {stats.recentSessions
+                .filter((s) => s.cost > 0)
+                .map((session) => (
+                  <div key={session.id} className="flex items-center justify-between px-3 py-2.5 first:pl-0 last:pr-0">
+                    <div className="min-w-0 pr-4">
+                      <p className="text-sm font-medium truncate">{session.projectName}</p>
+                      <p className="text-[11px] text-muted-foreground mt-0.5">{timeAgo(new Date(session.lastTime))}</p>
+                    </div>
+                    <div className="text-right shrink-0">
+                      <p className="text-sm font-semibold font-mono">
+                        <CostValue cost={session.cost} />
+                      </p>
+                      <p className="text-[11px] text-muted-foreground mt-0.5">{session.messageCount}개 메시지</p>
+                    </div>
+                  </div>
+                ))}
+              {stats.recentSessions.length === 0 && (
+                <p className="text-muted-foreground text-sm text-center py-4 col-span-3">세션이 없습니다</p>
+              )}
+            </div>
+          </CardContent>
+        </Card>
       </div>
-
-      <Card className="border-border/50">
-        <CardHeader className="pb-2">
-          <CardTitle className="text-sm font-medium">모델별 일별 비용</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <CostChart data={stats.dailyUsage} />
-        </CardContent>
-      </Card>
-
-      <Card className="border-border/50">
-        <CardHeader className="pb-2">
-          <CardTitle className="text-sm font-medium">대화 패턴 분석</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <ConversationStatsCard data={stats.conversationStats} />
-        </CardContent>
-      </Card>
-
-      <Card className="border-border/50">
-        <CardHeader className="pb-2">
-          <CardTitle className="text-sm font-medium">최근 세션</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="space-y-2">
-            {stats.recentSessions
-              .filter((s) => s.cost > 0)
-              .map((session) => (
-                <div
-                  key={session.id}
-                  className="flex items-center justify-between py-2 border-b border-border/50 last:border-0"
-                >
-                  <div>
-                    <p className="text-sm font-medium">{session.projectName}</p>
-                    <p className="text-xs text-muted-foreground">
-                      {timeAgo(new Date(session.lastTime))}
-                    </p>
-                  </div>
-                  <div className="text-right">
-                    <p className="text-sm font-medium">
-                      <CostValue cost={session.cost} />
-                    </p>
-                    <p className="text-xs text-muted-foreground">{session.messageCount}개 메시지</p>
-                  </div>
-                </div>
-              ))}
-            {stats.recentSessions.length === 0 && (
-              <p className="text-muted-foreground text-sm text-center py-4">세션이 없습니다</p>
-            )}
-          </div>
-        </CardContent>
-      </Card>
     </div>
   );
 }

--- a/packages/ui/src/pages/page-spinner.tsx
+++ b/packages/ui/src/pages/page-spinner.tsx
@@ -1,7 +1,10 @@
 export function PageSpinner() {
   return (
     <div className="flex items-center justify-center h-full min-h-96">
-      <div className="animate-spin rounded-full h-8 w-8 border-2 border-primary border-t-transparent" />
+      <div className="relative h-8 w-8">
+        <div className="absolute inset-0 rounded-full border-2 border-border" />
+        <div className="absolute inset-0 rounded-full border-2 border-transparent border-t-primary animate-spin" />
+      </div>
     </div>
   );
 }

--- a/packages/ui/src/pages/project-detail-page.tsx
+++ b/packages/ui/src/pages/project-detail-page.tsx
@@ -6,13 +6,10 @@ interface ProjectDetailPageProps {
 
 export function ProjectDetailPage({ id: _id }: ProjectDetailPageProps) {
   return (
-    <div className="space-y-6">
-      <div>
-        <Link to="/projects" className="text-sm text-muted-foreground hover:text-foreground">
-          &larr; 프로젝트 목록
-        </Link>
-        <h1 className="text-2xl font-semibold mt-2">프로젝트</h1>
-      </div>
+    <div className="space-y-4">
+      <Link to="/projects" className="inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors">
+        &larr; 프로젝트 목록
+      </Link>
       <p className="text-muted-foreground text-sm text-center py-8">
         세션 상세 보기는 현재 제공되지 않습니다.
       </p>

--- a/packages/ui/src/pages/projects-page.tsx
+++ b/packages/ui/src/pages/projects-page.tsx
@@ -1,6 +1,8 @@
 import { formatCost, formatNumber, formatTokens, getModelShortName, timeAgo } from '@repo/shared';
 import { Link } from '@tanstack/react-router';
 
+import { Clock, FolderOpen } from 'lucide-react';
+
 import { Badge } from '../components/ui/badge';
 import { Card, CardContent } from '../components/ui/card';
 import { useProjects } from '../hooks/use-data';
@@ -12,36 +14,62 @@ export function ProjectsPage() {
   if (isLoading) return <PageSpinner />;
 
   return (
-    <div className="space-y-6">
-      <div>
-        <h1 className="text-2xl font-semibold">프로젝트</h1>
-        <p className="text-muted-foreground text-sm mt-1">{projects?.length ?? 0}개 프로젝트</p>
-      </div>
-
-      <div className="grid gap-4">
+    <div className="space-y-4">
+      <div className="grid gap-3 grid-cols-1 md:grid-cols-2 xl:grid-cols-3 auto-rows-fr">
         {projects?.map((project) => (
           <Link key={project.id} to="/projects/$id" params={{ id: project.id }}>
-            <Card className="border-border/50 hover:border-border transition-colors cursor-pointer">
-              <CardContent className="p-4 space-y-1.5">
-                <div className="flex items-center gap-2 flex-wrap">
-                  <p className="font-medium">{project.name}</p>
-                  {project.models.slice(0, 3).map((model) => (
-                    <Badge key={model} variant="secondary" className="text-xs">
-                      {getModelShortName(model)}
-                    </Badge>
-                  ))}
+            <Card className="border-border hover:border-primary/30 transition-colors cursor-pointer group h-full">
+              <CardContent className="p-4 flex flex-col gap-3 h-full">
+                {/* 상단: 이름 + 배지 */}
+                <div>
+                  <div className="flex items-start justify-between gap-2 mb-1.5">
+                    <p className="font-medium text-sm group-hover:text-primary transition-colors leading-tight">
+                      {project.name}
+                    </p>
+                    <div className="flex gap-1 shrink-0 flex-wrap justify-end">
+                      {project.models.slice(0, 2).map((model) => (
+                        <Badge key={model} variant="secondary" className="text-[10px] px-1.5 py-0">
+                          {getModelShortName(model)}
+                        </Badge>
+                      ))}
+                    </div>
+                  </div>
+                  <p className="text-[11px] text-muted-foreground truncate">{project.path}</p>
                 </div>
-                <p className="text-xs text-muted-foreground truncate">{project.path}</p>
-                <p className="text-xs text-muted-foreground">
-                  {formatCost(project.totalCost)} · {formatTokens(project.totalTokens)} 토큰 ·{' '}
-                  {formatNumber(project.sessionCount)}개 세션 · {timeAgo(project.lastActivity)}
-                </p>
+
+                {/* 구분선 */}
+                <div className="h-px bg-border/50" />
+
+                {/* 하단: 통계 */}
+                <div className="grid grid-cols-3 gap-2 mt-auto">
+                  <div>
+                    <p className="text-[10px] text-muted-foreground uppercase tracking-wide">비용</p>
+                    <p className="text-xs font-medium font-mono mt-0.5">{formatCost(project.totalCost)}</p>
+                  </div>
+                  <div>
+                    <p className="text-[10px] text-muted-foreground uppercase tracking-wide">토큰</p>
+                    <p className="text-xs font-medium font-mono mt-0.5">{formatTokens(project.totalTokens)}</p>
+                  </div>
+                  <div>
+                    <p className="text-[10px] text-muted-foreground uppercase tracking-wide">세션</p>
+                    <p className="text-xs font-medium font-mono mt-0.5">{formatNumber(project.sessionCount)}개</p>
+                  </div>
+                </div>
+
+                {/* 마지막 활동 */}
+                <div className="flex items-center gap-1 text-[11px] text-muted-foreground">
+                  <Clock className="h-3 w-3 shrink-0" />
+                  <span>{timeAgo(project.lastActivity)}</span>
+                </div>
               </CardContent>
             </Card>
           </Link>
         ))}
         {(!projects || projects.length === 0) && (
-          <p className="text-muted-foreground text-sm text-center py-8">프로젝트가 없습니다</p>
+          <div className="col-span-3 flex flex-col items-center justify-center py-16 text-muted-foreground gap-2">
+            <FolderOpen className="h-8 w-8 opacity-30" />
+            <p className="text-sm">프로젝트가 없습니다</p>
+          </div>
         )}
       </div>
     </div>

--- a/packages/ui/src/pages/skills-page.tsx
+++ b/packages/ui/src/pages/skills-page.tsx
@@ -19,15 +19,16 @@ function SkillCard({ skill, onClick }: { skill: SkillInfo; onClick: () => void }
   return (
     <button
       onClick={onClick}
-      className="rounded-lg border border-border/50 bg-card p-4 space-y-2 text-left w-full hover:border-primary/50 hover:bg-muted/30 transition-colors cursor-pointer"
+      className="card-glass relative rounded-xl border overflow-hidden p-5 space-y-2.5 text-left w-full hover:border-primary/30 transition-all duration-200 group cursor-pointer"
     >
+      <div className="absolute left-0 top-0 bottom-0 w-[2px] bg-gradient-to-b from-primary/40 via-primary/20 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
       <div className="flex items-center justify-between gap-2">
         <div className="flex items-center gap-2">
           <Wand2 className="h-3.5 w-3.5 text-primary shrink-0" />
           <span className="text-sm font-medium">{skill.name}</span>
         </div>
         {skill.userInvocable && (
-          <Badge variant="secondary" className="text-[10px] px-1.5 py-0 shrink-0">
+          <Badge variant="secondary" className="text-[10px] px-1.5 py-0 shrink-0 font-mono">
             /{skill.name}
           </Badge>
         )}
@@ -48,14 +49,7 @@ export function SkillsPage({ skills, isLoading, isError }: SkillsPageProps) {
   const others = skills.filter((s) => !s.userInvocable);
 
   return (
-    <div className="space-y-6">
-      <div>
-        <h1 className="text-2xl font-semibold">스킬</h1>
-        <p className="text-muted-foreground text-sm mt-1">
-          ~/.claude/skills/ 에 등록된 커스텀 스킬 목록입니다.
-        </p>
-      </div>
-
+    <div className="space-y-5">
       {isLoading && <PageSpinner />}
 
       {isError && (
@@ -68,10 +62,10 @@ export function SkillsPage({ skills, isLoading, isError }: SkillsPageProps) {
 
       {invocable.length > 0 && (
         <section className="space-y-3">
-          <h2 className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+          <p className="text-[10px] font-semibold text-muted-foreground uppercase tracking-[0.2em]">
             호출 가능 ({invocable.length})
-          </h2>
-          <div className="grid gap-3 md:grid-cols-2">
+          </p>
+          <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
             {invocable.map((skill) => (
               <SkillCard key={skill.name} skill={skill} onClick={() => setSelected(skill)} />
             ))}
@@ -81,10 +75,10 @@ export function SkillsPage({ skills, isLoading, isError }: SkillsPageProps) {
 
       {others.length > 0 && (
         <section className="space-y-3">
-          <h2 className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+          <p className="text-[10px] font-semibold text-muted-foreground uppercase tracking-[0.2em]">
             기타 ({others.length})
-          </h2>
-          <div className="grid gap-3 md:grid-cols-2">
+          </p>
+          <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
             {others.map((skill) => (
               <SkillCard key={skill.name} skill={skill} onClick={() => setSelected(skill)} />
             ))}
@@ -93,25 +87,25 @@ export function SkillsPage({ skills, isLoading, isError }: SkillsPageProps) {
       )}
 
       <Dialog open={!!selected} onOpenChange={(open) => !open && setSelected(null)}>
-        <DialogContent className="max-w-2xl">
+        <DialogContent className="max-w-2xl card-glass border-border">
           <DialogHeader>
             <DialogTitle className="flex items-center gap-2 pr-6">
               <Wand2 className="h-4 w-4 text-primary shrink-0" />
-              {selected?.name}
+              <span className="font-semibold">{selected?.name}</span>
+              {selected?.userInvocable && (
+                <Badge variant="secondary" className="text-[10px] px-1.5 py-0 font-mono">
+                  /{selected.name}
+                </Badge>
+              )}
             </DialogTitle>
-            {selected?.userInvocable && (
-              <Badge variant="secondary" className="text-[10px] px-1.5 py-0 w-fit mt-2">
-                /{selected.name}
-              </Badge>
-            )}
           </DialogHeader>
           {selected?.description && (
-            <p className="text-sm text-muted-foreground border-b border-border/50 pb-4">
+            <p className="text-sm text-muted-foreground border-b border-border pb-4">
               {selected.description}
             </p>
           )}
           <ScrollArea className="max-h-[60vh]">
-            <pre className="text-xs leading-relaxed whitespace-pre-wrap text-foreground/80 pr-2">
+            <pre className="text-xs leading-relaxed whitespace-pre-wrap text-foreground/80 pr-2 font-mono">
               {selected?.body || '상세 내용이 없습니다.'}
             </pre>
           </ScrollArea>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -366,6 +366,12 @@ importers:
       '@radix-ui/react-accordion':
         specifier: ^1.2.12
         version: 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-dialog':
+        specifier: ^1.1.15
+        version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-dropdown-menu':
+        specifier: ^2.1.16
+        version: 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-progress':
         specifier: ^1.1.0
         version: 1.1.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -405,6 +411,9 @@ importers:
       lucide-react:
         specifier: 'catalog:'
         version: 0.468.0(react@19.2.4)
+      radix-ui:
+        specifier: ^1.4.3
+        version: 1.4.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react:
         specifier: 'catalog:'
         version: 19.2.4
@@ -1100,6 +1109,19 @@ packages:
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
 
+  '@radix-ui/react-accessible-icon@1.1.7':
+    resolution: {integrity: sha512-XM+E4WXl0OqUJFovy6GjmxxFyx9opfCAIUku4dlKRd5YEPqt4kALOkQOp0Of6reHuUkJuiPBEc5k0o4z4lTC8A==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-accordion@1.2.12':
     resolution: {integrity: sha512-T4nygeh9YE9dLRPhAHSeOZi7HBXo+0kYIPJXayZfvWOWA0+n3dESrZbjfDPUABkUNym6Hd+f2IR113To8D2GPA==}
     peerDependencies:
@@ -1113,8 +1135,60 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-alert-dialog@1.1.15':
+    resolution: {integrity: sha512-oTVLkEw5GpdRe29BqJ0LSDFWI3qu0vR1M0mUkOQWDIUnY/QIkLpgDMWuKxP94c2NAC2LGcgVhG1ImF3jkZ5wXw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-arrow@1.1.7':
     resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-aspect-ratio@1.1.7':
+    resolution: {integrity: sha512-Yq6lvO9HQyPwev1onK1daHCHqXVLzPhSVjmsNjCa2Zcxy2f7uJD2itDtxknv6FzAKCwD1qQkeVDmX/cev13n/g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-avatar@1.1.10':
+    resolution: {integrity: sha512-V8piFfWapM5OmNCXTzVQY+E1rDa53zY+MQ4Y7356v4fFz6vqCyUtIz2rUD44ZEdwg78/jKmMJHj07+C/Z/rcog==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-checkbox@1.3.3':
+    resolution: {integrity: sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1161,6 +1235,19 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-context-menu@2.2.16':
+    resolution: {integrity: sha512-O8morBEW+HsVG28gYDZPTrT9UUovQUlJue5YO836tiTJhuIWBm/zQHc7j388sHWtdH/xUZurK9olD2+pcqx5ww==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-context@1.1.2':
     resolution: {integrity: sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==}
     peerDependencies:
@@ -1179,6 +1266,19 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-dialog@1.1.15':
+    resolution: {integrity: sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-direction@1.1.1':
     resolution: {integrity: sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==}
     peerDependencies:
@@ -1190,6 +1290,19 @@ packages:
 
   '@radix-ui/react-dismissable-layer@1.1.11':
     resolution: {integrity: sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-dropdown-menu@2.1.16':
+    resolution: {integrity: sha512-1PLGQEynI/3OX/ftV54COn+3Sud/Mn8vALg2rWnBLnRaGtJDduNW/22XjlGgPdpcIbiQxjKtb7BkcjP00nqfJw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1223,6 +1336,32 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-form@0.1.8':
+    resolution: {integrity: sha512-QM70k4Zwjttifr5a4sZFts9fn8FzHYvQ5PiB19O2HsYibaHSVt9fH9rzB0XZo/YcM+b7t/p7lYCT/F5eOeF5yQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-hover-card@1.1.15':
+    resolution: {integrity: sha512-qgTkjNT1CfKMoP0rcasmlH2r1DAiYicWsDsufxl940sT2wHNEWWv6FMWIQXWhVdmC1d/HYfbhQx60KYyAtKxjg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-id@1.1.1':
     resolution: {integrity: sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==}
     peerDependencies:
@@ -1230,6 +1369,97 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-label@2.1.7':
+    resolution: {integrity: sha512-YT1GqPSL8kJn20djelMX7/cTRp/Y9w5IZHvfxQTVHrOqa2yMl7i/UfMqKRU5V7mEyKTrUVgJXhNQPVCG8PBLoQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-menu@2.1.16':
+    resolution: {integrity: sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-menubar@1.1.16':
+    resolution: {integrity: sha512-EB1FktTz5xRRi2Er974AUQZWg2yVBb1yjip38/lgwtCVRd3a+maUoGHN/xs9Yv8SY8QwbSEb+YrxGadVWbEutA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-navigation-menu@1.2.14':
+    resolution: {integrity: sha512-YB9mTFQvCOAQMHU+C/jVl96WmuWeltyUEpRJJky51huhds5W2FQr1J8D/16sQlf0ozxkPK8uF3niQMdUwZPv5w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-one-time-password-field@0.1.8':
+    resolution: {integrity: sha512-ycS4rbwURavDPVjCb5iS3aG4lURFDILi6sKI/WITUMZ13gMmn/xGjpLoqBAalhJaDk8I3UbCM5GzKHrnzwHbvg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-password-toggle-field@0.1.3':
+    resolution: {integrity: sha512-/UuCrDBWravcaMix4TdT+qlNdVwOM1Nck9kWx/vafXsdfj1ChfhOdfi3cy9SGBpWgTXwYCuboT/oYpJy3clqfw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-popover@1.1.15':
+    resolution: {integrity: sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-popper@1.2.8':
@@ -1297,8 +1527,34 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-progress@1.1.7':
+    resolution: {integrity: sha512-vPdg/tF6YC/ynuBIJlk1mm7Le0VgW6ub6J2UWnTQ7/D23KXcPI1qy+0vBkgKgd38RCMJavBXpB83HPNFMTb0Fg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-progress@1.1.8':
     resolution: {integrity: sha512-+gISHcSPUJ7ktBy9RnTqbdKW78bcGke3t6taawyZ71pio1JewwGSJizycs7rLhGTvMJYCQB1DBK4KQsxs7U8dA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-radio-group@1.3.8':
+    resolution: {integrity: sha512-VBKYIYImA5zsxACdisNQ3BjCBfmbGH3kQlnFVqlWU4tXwjy7cGX8ta80BcrO+WJXIn5iBylEH3K6ZTlee//lgQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1349,8 +1605,34 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-separator@1.1.7':
+    resolution: {integrity: sha512-0HEb8R9E8A+jZjvmFCy/J4xhbXy3TV+9XSnGJ3KvTtjlIUy/YQ/p6UYZvi7YbeoeXdyU9+Y3scizK6hkY37baA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-separator@1.1.8':
     resolution: {integrity: sha512-sDvqVY4itsKwwSMEe0jtKgfTh+72Sy3gPmQpjqcQneqQ4PFmr/1I0YA+2/puilhggCe2gJcx5EBAYFkWkdpa5g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-slider@1.3.6':
+    resolution: {integrity: sha512-JPYb1GuM1bxfjMRlNLE+BcmBC8onfCi60Blk7OBqi2MLTFdS+8401U4uFjnwkOr49BLmXxLC6JHkvAsx5OJvHw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1380,8 +1662,73 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-switch@1.2.6':
+    resolution: {integrity: sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-tabs@1.1.13':
     resolution: {integrity: sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toast@1.2.15':
+    resolution: {integrity: sha512-3OSz3TacUWy4WtOXV38DggwxoqJK4+eDkNMl5Z/MJZaoUPaP4/9lf81xXMe1I2ReTAptverZUpbPY4wWwWyL5g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toggle-group@1.1.11':
+    resolution: {integrity: sha512-5umnS0T8JQzQT6HbPyO7Hh9dgd82NmS36DQr+X/YJ9ctFNCiiQd6IJAYYZ33LUwm8M+taCz5t2ui29fHZc4Y6Q==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toggle@1.1.10':
+    resolution: {integrity: sha512-lS1odchhFTeZv3xwHH31YPObmJn8gOg7Lq12inrr0+BH/l3Tsq32VfjqH1oh80ARM3mlkfMic15n0kg4sD1poQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toolbar@1.1.11':
+    resolution: {integrity: sha512-4ol06/1bLoFu1nwUqzdD4Y5RZ9oDdKeiHIsntug54Hcr1pgaHiPqHFEaXI1IFP/EsOfROQZ8Mig9VTIRza6Tjg==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1435,6 +1782,15 @@ packages:
 
   '@radix-ui/react-use-escape-keydown@1.1.1':
     resolution: {integrity: sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-is-hydrated@0.1.0':
+    resolution: {integrity: sha512-U+UORVEq+cTnRIaostJv9AGdV3G6Y+zbVd+12e18jQ5A3c0xL03IhnHuiU4UV69wolOQp5GfR58NW/EgdQhwOA==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -3835,6 +4191,19 @@ packages:
     resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
     engines: {node: '>=10'}
 
+  radix-ui@1.4.3:
+    resolution: {integrity: sha512-aWizCQiyeAenIdUbqEpXgRA1ya65P13NKn/W8rWkcN0OPkRDxdBVLWnIEDsS2RpwCK2nobI7oMUSmexzTDyAmA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   react-dom@19.2.4:
     resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
     peerDependencies:
@@ -5167,6 +5536,15 @@ snapshots:
 
   '@radix-ui/primitive@1.1.3': {}
 
+  '@radix-ui/react-accessible-icon@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-accordion@1.2.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
@@ -5184,9 +5562,61 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
+  '@radix-ui/react-alert-dialog@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-aspect-ratio@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-avatar@1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-is-hydrated': 0.1.0(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-checkbox@1.3.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
@@ -5227,6 +5657,20 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  '@radix-ui/react-context-menu@2.2.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-context@1.1.2(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
       react: 19.2.4
@@ -5238,6 +5682,28 @@ snapshots:
       react: 19.2.4
     optionalDependencies:
       '@types/react': 19.2.14
+
+  '@radix-ui/react-dialog@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      aria-hidden: 1.2.6
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
   '@radix-ui/react-direction@1.1.1(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
@@ -5252,6 +5718,21 @@ snapshots:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-dropdown-menu@2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
@@ -5275,12 +5756,177 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
+  '@radix-ui/react-form@0.1.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-label': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-hover-card@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-id@1.1.1(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
       react: 19.2.4
     optionalDependencies:
       '@types/react': 19.2.14
+
+  '@radix-ui/react-label@2.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-menu@2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      aria-hidden: 1.2.6
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-menubar@1.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-navigation-menu@1.2.14(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-one-time-password-field@0.1.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/number': 1.1.1
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-is-hydrated': 0.1.0(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-password-toggle-field@0.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-is-hydrated': 0.1.0(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      aria-hidden: 1.2.6
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
   '@radix-ui/react-popper@1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
@@ -5338,10 +5984,38 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
+  '@radix-ui/react-progress@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-progress@1.1.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/react-context': 1.1.3(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-radio-group@1.3.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
@@ -5411,9 +6085,37 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
+  '@radix-ui/react-separator@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-separator@1.1.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-slider@1.3.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/number': 1.1.1
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
@@ -5434,6 +6136,21 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  '@radix-ui/react-switch@1.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-tabs@1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
@@ -5444,6 +6161,67 @@ snapshots:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-toast@1.2.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-toggle-group@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-toggle': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-toggle@1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-toolbar@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-separator': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-toggle-group': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
@@ -5495,6 +6273,13 @@ snapshots:
     dependencies:
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
       react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-is-hydrated@0.1.0(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+      use-sync-external-store: 1.6.0(react@19.2.4)
     optionalDependencies:
       '@types/react': 19.2.14
 
@@ -8178,6 +8963,69 @@ snapshots:
   punycode@2.3.1: {}
 
   quick-lru@5.1.1: {}
+
+  radix-ui@1.4.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-accessible-icon': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-accordion': 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-alert-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-aspect-ratio': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-avatar': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-checkbox': 1.3.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-collapsible': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context-menu': 2.2.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-dropdown-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-form': 0.1.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-hover-card': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-label': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-menubar': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-navigation-menu': 1.2.14(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-one-time-password-field': 0.1.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-password-toggle-field': 0.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-popover': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-progress': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-radio-group': 1.3.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-scroll-area': 1.2.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-select': 2.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-separator': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slider': 1.3.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-switch': 1.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-toast': 1.2.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-toggle': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-toggle-group': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-toolbar': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-tooltip': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-is-hydrated': 0.1.0(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
   react-dom@19.2.4(react@19.2.4):
     dependencies:


### PR DESCRIPTION


## Summary

feat: glass bento 리디자인 + 사이드바 개편

## Changes

- glass morphism 카드 시스템 및 12열 bento grid 레이아웃
- 다크/라이트 테마 전환 (view transition API 원형 reveal)
- 사이드바 collapsible icon 모드 전환
- 사이드바 footer dropdown menu 패턴 적용
- 상단 topbar 추가 및 페이지별 중복 헤더 제거
- 차트 툴팁 popover 배경색으로 가독성 개선

